### PR TITLE
embellishments to the logging system

### DIFF
--- a/dexbot/basestrategy.py
+++ b/dexbot/basestrategy.py
@@ -6,7 +6,6 @@ from bitshares.price import FilledOrder, Order, UpdateCallOrder
 from bitshares.instance import shared_bitshares_instance
 from .storage import Storage
 from .statemachine import StateMachine
-log = logging.getLogger(__name__)
 
 
 class BaseStrategy(Storage, StateMachine, Events):
@@ -29,6 +28,8 @@ class BaseStrategy(Storage, StateMachine, Events):
          * ``basestrategy.market``: The market used by this bot
          * ``basestrategy.orders``: List of open orders of the bot's account in the bot's market
          * ``basestrategy.balance``: List of assets and amounts available in the bot's account
+         * ``basestrategy.log``: a per-bot logger (actually LoggerAdapter) adds bot-specific context: botname & account
+           (Because some UIs might want to display per-bot logs)
 
         Also, Base Strategy inherits :class:`stakemachine.storage.Storage`
         which allows to permanently store data in a sqlite database
@@ -37,6 +38,10 @@ class BaseStrategy(Storage, StateMachine, Events):
         ``basestrategy["key"] = "value"``
 
         .. note:: This applies a ``json.loads(json.dumps(value))``!
+
+    Bots must never attempt to interact with the user, they must assume they are running unattended
+    They can log events. If a problem occurs they can't fix they should set self.disabled = True and throw an exception
+    The framework catches all exceptions thrown from event handlers and logs appropriately.
     """
 
     __events__ = [
@@ -112,6 +117,12 @@ class BaseStrategy(Storage, StateMachine, Events):
         # will be reset to False after reset only
         self.disabled = False
 
+        # a private logger that adds bot identify data to the LogRecord
+        self.log = logging.LoggerAdapter(logging.getLogger('dexbot.per_bot'),{'botname':name,
+                                                                                 'account':self.bot['account'],
+                                                                                 'market':self.bot['market'],
+                                                                                 'is_disabled':(lambda: self.disabled)})
+    
     @property
     def orders(self):
         """ Return the bot's open accounts in the current market

--- a/dexbot/bot.py
+++ b/dexbot/bot.py
@@ -4,8 +4,14 @@ import time
 import logging
 from bitshares.notify import Notify
 from bitshares.instance import shared_bitshares_instance
+
 log = logging.getLogger(__name__)
 
+log_bots = logging.getLogger('dexbot.per_bot')
+# NOTE this is the  special logger for per-bot events
+# it  returns LogRecords with extra fields: botname, account, market and is_disabled
+# is_disabled is a callable returning True if the bot is currently disabled.
+# GUIs can add a handler to this logger to get a stream of events re the running bots.
 
 class BotInfrastructure():
 
@@ -14,7 +20,7 @@ class BotInfrastructure():
     def __init__(
         self,
         config,
-        bitshares_instance=None,
+        bitshares_instance=None
     ):
         # BitShares instance
         self.bitshares = bitshares_instance or shared_bitshares_instance()
@@ -24,14 +30,29 @@ class BotInfrastructure():
         # Load all accounts and markets in use to subscribe to them
         accounts = set()
         markets = set()
+        
+        # Initialize bots:
         for botname, bot in config["bots"].items():
             if "account" not in bot:
-                raise ValueError("Bot %s has no account" % botname)
+                log_bots.critical("Bot has no account",extra={'botname':botname,'account':'unknown','market':'unknown','is_dsabled':(lambda: True)})
+                continue
             if "market" not in bot:
-                raise ValueError("Bot %s has no market" % botname)
-
-            accounts.add(bot["account"])
-            markets.add(bot["market"])
+                log_bots.critical("Bot has no market",extra={'botname':botname,'account':bot['account'],'market':'unknown','is_disabled':(lambda: True)})
+                continue
+            try:
+                klass = getattr(
+                    importlib.import_module(bot["module"]),
+                    bot["bot"]
+                )
+                self.bots[botname] = klass(
+                    config=config,
+                    name=botname,
+                    bitshares_instance=self.bitshares
+                )
+                markets.add(bot['market'])
+                accounts.add(bot['account'])
+            except:
+                log_bots.exception("Bot initialisation",extra={'botname':botname,'account':bot['account'],'market':'unknown','is_disabled':(lambda: True)})
 
         # Create notification instance
         # Technically, this will multiplex markets and accounts and
@@ -45,17 +66,6 @@ class BotInfrastructure():
             bitshares_instance=self.bitshares
         )
 
-        # Initialize bots:
-        for botname, bot in config["bots"].items():
-            klass = getattr(
-                importlib.import_module(bot["module"]),
-                bot["bot"]
-            )
-            self.bots[botname] = klass(
-                config=config,
-                name=botname,
-                bitshares_instance=self.bitshares
-            )
 
     # Events
     def on_block(self, data):
@@ -66,49 +76,35 @@ class BotInfrastructure():
                 self.bots[botname].ontick(data)
             except Exception as e:
                 self.bots[botname].error_ontick(e)
-                log.error(
-                    "Error while processing {botname}.tick(): {exception}\n{stack}".format(
-                        botname=botname,
-                        exception=str(e),
-                        stack=traceback.format_exc()
-                    ))
+                self.bots[botname].log.exception("in .tick()")
 
     def on_market(self, data):
         if data.get("deleted", False):  # no info available on deleted orders
             return
         for botname, bot in self.config["bots"].items():
             if self.bots[botname].disabled:
-                log.info("The bot %s has been disabled" % botname)
+                self.bots[botname].log.warning("disabled")
                 continue
             if bot["market"] == data.market:
                 try:
                     self.bots[botname].onMarketUpdate(data)
                 except Exception as e:
                     self.bots[botname].error_onMarketUpdate(e)
-                    log.error(
-                        "Error while processing {botname}.onMarketUpdate(): {exception}\n{stack}".format(
-                            botname=botname,
-                            exception=str(e),
-                            stack=traceback.format_exc()
-                        ))
+                    self.bots[botname].log.exception(".onMarketUpdate()")
 
     def on_account(self, accountupdate):
         account = accountupdate.account
         for botname, bot in self.config["bots"].items():
             if self.bots[botname].disabled:
-                log.info("The bot %s has been disabled" % botname)
+                self.bot[botname].log.info("The bot %s has been disabled" % botname)
                 continue
             if bot["account"] == account["name"]:
                 try:
                     self.bots[botname].onAccount(accountupdate)
                 except Exception as e:
                     self.bots[botname].error_onAccount(e)
-                    log.error(
-                        "Error while processing {botname}.onAccount(): {exception}\n{stack}".format(
-                            botname=botname,
-                            exception=str(e),
-                            stack=traceback.format_exc()
-                        ))
+                    self.bots[botname].log.exception(".onAccountUpdate()")
 
     def run(self):
         self.notify.listen()
+

--- a/dexbot/strategies/echo.py
+++ b/dexbot/strategies/echo.py
@@ -1,9 +1,8 @@
 from dexbot.basestrategy import BaseStrategy
-import logging
-log = logging.getLogger(__name__)
-
 
 class Echo(BaseStrategy):
+
+    
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -33,7 +32,7 @@ class Echo(BaseStrategy):
 
             :param bitshares.price.FilledOrder i: Filled order details
         """
-        print("order matched: %s" % i)
+        self.log.info("order matched: %s" % i)
 
     def print_orderPlaced(self, i):
         """ Is called when a new order in the market is placed
@@ -43,7 +42,7 @@ class Echo(BaseStrategy):
 
             :param bitshares.price.Order i: Order details
         """
-        print("order placed:  %s" % i)
+        self.log.info("order placed:  %s" % i)
 
     def print_UpdateCallOrder(self, i):
         """ Is called when a call order for a market pegged asset is updated
@@ -53,7 +52,7 @@ class Echo(BaseStrategy):
 
             :param bitshares.price.CallOrder i: Call order details
         """
-        print("call update:   %s" % i)
+        self.log.info("call update:   %s" % i)
 
     def print_marketUpdate(self, i):
         """ Is called when Something happens in your market.
@@ -64,7 +63,7 @@ class Echo(BaseStrategy):
 
             :param object i: Can be instance of ``FilledOrder``, ``Order``, or ``CallOrder``
         """
-        print("marketupdate:  %s" % i)
+        self.log.info("marketupdate:  %s" % i)
 
     def print_newBlock(self, i):
         """ Is called when a block is received
@@ -76,7 +75,7 @@ class Echo(BaseStrategy):
                       need to know the most recent block number, you
                       need to use ``bitshares.blockchain.Blockchain``
         """
-        print("new1 block:     %s" % i)
+        self.log.info("new1 block:     %s" % i)
         # raise ValueError("Testing disabling")
 
     def print_accountUpdate(self, i):
@@ -84,4 +83,4 @@ class Echo(BaseStrategy):
             any update. This includes anything that changes
             ``2.6.xxxx``, e.g., any operation that affects your account.
         """
-        print("account:       %s" % i)
+        self.log.info("account:       %s" % i)

--- a/dexbot/strategies/walls.py
+++ b/dexbot/strategies/walls.py
@@ -4,8 +4,7 @@ from collections import Counter
 from bitshares.amount import Amount
 from dexbot.basestrategy import BaseStrategy
 from dexbot.errors import InsufficientFundsError
-import logging
-log = logging.getLogger(__name__)
+
 
 
 class Walls(BaseStrategy):
@@ -30,12 +29,12 @@ class Walls(BaseStrategy):
     def error(self, *args, **kwargs):
         self.disabled = True
         self.cancelall()
-        pprint(self.execute())
+        self.log.info(self.execute())
 
     def updateorders(self):
         """ Update the orders
         """
-        log.info("Replacing orders")
+        self.log.info("Replacing orders")
 
         # Canceling orders
         self.cancelall()
@@ -75,7 +74,7 @@ class Walls(BaseStrategy):
                 account=self.account
             )
 
-        pprint(self.execute())
+        self.log.info(self.execute())
 
     def getprice(self):
         """ Here we obtain the price for the quote and make sure it has
@@ -108,7 +107,7 @@ class Walls(BaseStrategy):
                 not self["insufficient_buy"] and
                 not self["insufficient_sell"]
             ):
-                log.info("No 2 orders available. Updating orders!")
+                self.log.info("No 2 orders available. Updating orders!")
                 self.updateorders()
         elif len(orders) == 0:
             self.updateorders()
@@ -118,5 +117,5 @@ class Walls(BaseStrategy):
             self["feed_price"] and
             fabs(1 - float(self.getprice()) / self["feed_price"]) > self.bot["threshold"] / 100.0
         ):
-            log.info("Price feed moved by more than the threshold. Updating orders!")
+            self.log.info("Price feed moved by more than the threshold. Updating orders!")
             self.updateorders()

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -14,17 +14,33 @@ log = logging.getLogger(__name__)
 def verbose(f):
     @click.pass_context
     def new_func(ctx, *args, **kwargs):
-        global log
         verbosity = [
             "critical", "error", "warn", "info", "debug"
         ][int(min(ctx.obj.get("verbose", 0), 4))]
-        log.setLevel(getattr(logging, verbosity.upper()))
-        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        if ctx.obj.get("systemd",False):
+            # dont print the timestamps: systemd will log it for us
+            formatter1 = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
+            formatter2 = logging.Formatter('bot %(botname)s using account %(account)s on %(market)s - %(levelname)s - %(message)s')
+        elif verbosity == "debug":
+            # when debugging log where the log call came from
+            formatter1 = logging.Formatter('%(asctime)s (%(module)s:%(lineno)d) - %(levelname)s - %(message)s')
+            formatter2 = logging.Formatter('%(asctime)s (%(module)s:%(lineno)d) - bot %(botname)s - %(levelname)s - %(message)s')           
+        else:
+            formatter1 = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            formatter2 = logging.Formatter('%(asctime)s - bot %(botname)s using account %(account)s on %(market)s - %(levelname)s - %(message)s')
+
+        # use special format for special bots logger
         ch = logging.StreamHandler()
         ch.setLevel(getattr(logging, verbosity.upper()))
-        ch.setFormatter(formatter)
-        log.addHandler(ch)
-
+        ch.setFormatter(formatter2)
+        logging.getLogger("dexbot.per_bot").addHandler(ch)
+        logging.getLogger("dexbot.per_bot").propagate = False # don't double up with root logger
+        # set the root logger with basic format
+        ch = logging.StreamHandler()
+        ch.setLevel(getattr(logging, verbosity.upper()))
+        ch.setFormatter(formatter1)
+        logging.getLogger("dexbot").addHandler(ch)
+        
         # GrapheneAPI logging
         if ctx.obj["verbose"] > 4:
             verbosity = [


### PR DESCRIPTION
each bot instance gets its own LoggerAdapter (same interface as standard Python Logger)
difference is basestrategy adds appropriate bot metadata (bot name, market, account and disabled status) to each log entry through the "extra" field.
ui.py is updated so text logs have this information. also date information is suppressed when using systemd (as journald will add it for us)
but main point is for GUI code to tap the stream of log entries using
getLogger('dexbot.bot.per_bot') and display the log in an interesting way (per bot log window, colour-coded, etc)