### PR TITLE
allow users to optionally have a ~/bots directory for their own bots.

### DIFF
--- a/dexbot/bot.py
+++ b/dexbot/bot.py
@@ -2,6 +2,7 @@ import traceback
 import importlib
 import time
 import logging
+import os.path
 from bitshares.notify import Notify
 from bitshares.instance import shared_bitshares_instance
 log = logging.getLogger(__name__)
@@ -44,6 +45,11 @@ class BotInfrastructure():
             on_block=self.on_block,
             bitshares_instance=self.bitshares
         )
+
+        # set the module search path
+        userbotpath = os.path.expanduser("~/bots")
+        if os.path.exists(userbotpath):
+            sys.path.append(userbotpath)
 
         # Initialize bots:
         for botname, bot in config["bots"].items():


### PR DESCRIPTION
this is a very simple change to allow easy access to user-written bots.
the original stakemachine only lets you load bots accessible from the standard sys.path
which makes it tricky to load your own bot: you would have to set PYTHONPATH before doing 'dexbot run'
this is a pure convience feature to add ~/bots to sys.path if it exists.
no change in behaviour if users have no such directory.