### PR TITLE
Follow orders

### DIFF
--- a/dexbot/strategies/follow_orders.py
+++ b/dexbot/strategies/follow_orders.py
@@ -1,0 +1,137 @@
+from math import fabs
+from pprint import pprint
+from collections import Counter
+from bitshares.amount import Amount
+from bitshares.price import Price, Order, FilledOrder
+from dexbot.basestrategy import BaseStrategy, ConfigElement
+
+import pdb
+        
+class Strategy(BaseStrategy):
+
+    @classmethod
+    def configure(cls):
+        return BaseStrategy.configure()+[
+            ConfigElement("spread","float",5,"Percentage difference between buy and sell",(0,1000)),
+            ConfigElement("wall","float",0.0,"the default amount to buy/sell, in quote",(0.0,None)),
+            ConfigElement("max","float",100.0,"bot will not trade if price above this",(0,0,None)),
+            ConfigElement("min","float",100.0,"bot will not trade if price below this",(0,0,None)),
+            ConfigElement("start","float",100.0,"Starting price, as percentage of settlement price",(0,0,None)),
+            ConfigElement("reset","bool",False,"bot will alwys reset orders on start",(0,0,None)),
+        ]
+
+
+    def safe_dissect(self,thing,name):
+        try:
+            self.log.info("%s() returned type: %r repr: %r dict: %r" % (name,type(thing),repr(thing),dict(thing)))
+        except:
+            self.log.info("%s() returned type: %r repr: %r" % (name,type(thing),repr(thing)))
+
+
+    def add_price(self,p1,p2):
+        if not p1: return p2
+        return Price(quote=p1['quote']+p2['quote'],base=p1['base']+p2['base'])
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Define Callbacks
+        self.onMarketUpdate += self.onmarket
+        if self.bot.get("reset",False):
+            self.cancelall()
+        self.reassess()
+                                           
+    def updateorders(self,newprice):
+        """ Update the orders
+        """
+
+        self.log.info("Replacing orders")
+
+        sell_price = newprice * (100+(self.bot['spread']/2))/100.0
+        buy_price = newprice * (100-(self.bot['spread']/2))/100.0
+        
+        # Canceling orders
+        self.cancelall()
+        myorders = {}
+
+        if newprice < self.bot["min"]:
+            self.disabled = True
+            self.log.critical("Price %f is below minimum %f" % (newprice,sel.bot["min"]))
+            return
+        if newprice > self.bot["max"]:
+            self.disabled = True
+            self.log.critical("Price %f is above maxiimum %f" % (newprice,sel.bot["max"]))
+            return
+        
+        if float(self.balance(self.market["quote"])) < self.bot["wall"]:
+            self.log.critical("insufficient sell balance: %r (needed %f)" % (self.balance(self.market["quote"]),self.bot["wall"]))
+            self.disabled = True # now we get no more events
+            return
+
+        if self.balance(self.market["base"]) < buy_price * self.bot["wall"]:
+            self.disabled = True
+            self.log.critical("insufficient buy balance: %r (need: %f)" % (self.balance(self.market["base"]),self.bot["wall"]*buy_price))
+            return
+    
+        amt = Amount(self.bot["wall"], self.market["quote"])
+        self.log.info("SELL {amt} at {price} {base}/{quote} (= {inv_price} {quote}/{base})".format(
+            amt=repr(amt),
+            price=sell_price,
+            inv_price = 1/sell_price,
+            quote=self.market['quote']['symbol'],
+            base=self.market['base']['symbol']))
+        
+        ret = self.market.sell(
+                sell_price,
+                amt,
+                account=self.account,
+                returnOrderId="head"
+            )
+        myorders[ret['orderid']] = sell_price
+        self.log.info("BUY {amt} at {price} {base}/{quote} (= {inv_price} {quote}/{base})".format(
+            amt=repr(amt),
+            price = buy_price,
+            inv_price = 1/buy_price,
+            quote=self.market['quote']['symbol'],
+            base=self.market['base']['symbol']))
+        ret = self.market.buy(
+                buy_price,
+                amt,
+                account=self.account,
+                    returnOrderId="head",
+            )
+        myorders[ret['orderid']] = buy_price
+
+        self['myorders'] = myorders
+        #ret = self.execute() this doesn't seem to work reliably
+        #self.safe_dissect(ret,"execute")
+
+    def onmarket(self, data):
+        if type(data) is FilledOrder and data['account_id'] == self.account['id']:
+            self.info("FilledOrder %r" % dict(data))
+            if data['quote']['asset'] == self.market['quote']:
+                self.info("I think its a SELL to us of %r" % data['quote'])
+            if data['base']['asset'] == self.market['quote']:
+                self.info("I think its a BUY from us of %r" % data['base'])
+            self.reassess()
+
+    def reassess(self):
+        # sadly no smart way to match a FilledOrder to an existing order
+        # even price-matching won't work as we can buy at a better price than we asked for
+        # so look at what's missing
+        self.account.refresh()
+        still_open = set(i['id'] for i in self.account.openorders)
+        if len(still_open) == 0:
+            self.log.info("no open orders, recalculating from startprice")
+            t = self.market.ticker()
+            self.updateorders(float(t['quoteSettlement_price'])*self.bot['start']/100.0)
+            return
+        missing = set(self['myorders'].keys()) - still_open
+        if len(missing) == 2:
+            self.log.critical("Aaargh! there are open orders but both of ours have gone. Probably because user is doing other trades with bot's account. Suspening bot.")
+            self.disabled = True
+            return
+        if len(missing) == 1:
+            # one surviving order and one missing, use the missing one as new price
+            for i in missing:
+                self.updateorders(self['myorders'][i])
+

--- a/dexbot/strategies/follow_orders.py
+++ b/dexbot/strategies/follow_orders.py
@@ -12,13 +12,14 @@ class Strategy(BaseStrategy):
     @classmethod
     def configure(cls):
         return BaseStrategy.configure()+[
-            ConfigElement("spread","float",5,"Percentage difference between buy and sell",(0,1000)),
+            ConfigElement("spread","float",5,"Percentage difference between buy and sell",(0,100)),
             ConfigElement("wall","float",0.0,"the default amount to buy/sell, in quote",(0.0,None)),
             ConfigElement("max","float",100.0,"bot will not trade if price above this",(0.0,None)),
             ConfigElement("min","float",100.0,"bot will not trade if price below this",(0.0,None)),
             ConfigElement("start","float",100.0,"Starting price, as percentage of settlement price",(0.0,None)),
             ConfigElement("reset","bool",False,"bot will alwys reset orders on start",(0.0,None)),
-            ConfigElement("staggers","int",1,"Number of additional staggered orders to place",(1,100))
+            ConfigElement("staggers","int",1,"Number of additional staggered orders to place",(1,100)),
+            ConfigElement("staggerspread","float",5,"Percentage difference between staggered orders",(1,100))
         ]
 
 
@@ -38,7 +39,7 @@ class Strategy(BaseStrategy):
         # Define Callbacks
         self.onMarketUpdate += self.onmarket
         if self.bot.get("reset",False):
-            self.cancelall()
+            self.cancel_all()
         self.reassess()
                                            
     def updateorders(self,newprice):
@@ -47,20 +48,19 @@ class Strategy(BaseStrategy):
 
         self.log.info("Replacing orders. Baseprice is %f" % newprice)
         self['price'] = newprice
-        step = (self.bot['spread']/2)/100.0
-        
+        step1 = (self.bot['spread']/2)/100.0
+        step2 = self.bot['staggerspread']/100.0
         # Canceling orders
-        self.cancelall()
-
+        self.cancel_all()
         myorders = {}
 
         if newprice < self.bot["min"]:
             self.disabled = True
-            self.log.critical("Price %f is below minimum %f" % (newprice,sel.bot["min"]))
+            self.log.critical("Price %f is below minimum %f" % (newprice,self.bot["min"]))
             return
         if newprice > self.bot["max"]:
             self.disabled = True
-            self.log.critical("Price %f is above maxiimum %f" % (newprice,sel.bot["max"]))
+            self.log.critical("Price %f is above maximum %f" % (newprice,self.bot["max"]))
             return
         
         if float(self.balance(self.market["quote"])) < self.bot["wall"]*self.bot['staggers']:
@@ -75,27 +75,26 @@ class Strategy(BaseStrategy):
     
         amt = Amount(self.bot["wall"], self.market["quote"])
         
-        sell_price = newprice
+        sell_price = newprice+step1
         for i in range(0,self.bot['staggers']):
-            sell_price += step
             self.log.info("SELL {amt} at {price} {base}/{quote} (= {inv_price} {quote}/{base})".format(
                 amt=repr(amt),
                 price=sell_price,
                 inv_price = 1/sell_price,
                 quote=self.market['quote']['symbol'],
                 base=self.market['base']['symbol']))
-            
             ret = self.market.sell(
                 sell_price,
                 amt,
                 account=self.account,
                 returnOrderId="head"
             )
+            self.log.info("SELL order done")
             myorders[ret['orderid']] = sell_price
-
-        buy_price = newprice
+            sell_price += step2
+            
+        buy_price = newprice-step1
         for i in range(0,self.bot['staggers']):
-            buy_price -= step
             self.log.info("BUY {amt} at {price} {base}/{quote} (= {inv_price} {quote}/{base})".format(
                 amt=repr(amt),
                 price = buy_price,
@@ -108,15 +107,16 @@ class Strategy(BaseStrategy):
                 account=self.account,
                 returnOrderId="head",
             )
+            self.log.info("BUY order done")
             myorders[ret['orderid']] = buy_price
-
+            buy_price -= step2
         self['myorders'] = myorders
         #ret = self.execute() this doesn't seem to work reliably
         #self.safe_dissect(ret,"execute")
 
     def onmarket(self, data):
+        self.log.info("%r %r" % (type(data),dict(data)))
         if type(data) is FilledOrder and data['account_id'] == self.account['id']:
-            self.log.info("FilledOrder %r" % dict(data))
             self.log.info("data['quote']['asset'] = %r self.market['quote'] = %r" % (data['quote']['asset'],self.market['quote']))
             if data['quote']['asset'] == self.market['quote']:
                 self.log.info("I think its a SELL to us of %r" % data['quote'])
@@ -144,5 +144,5 @@ class Strategy(BaseStrategy):
                 if diff > highest_diff:
                     found_price = self['myorders'][i]
                     highest_diff = diff
-            self.updateorders(self['myorders'][i])
+            self.updateorders(found_price)
 

--- a/dexbot/strategies/follow_orders.py
+++ b/dexbot/strategies/follow_orders.py
@@ -216,6 +216,14 @@ class Strategy(BaseStrategy):
         if len(still_open) == 0:
             self.log.info("no open orders, recalculating the startprice")
             t = self.market.ticker()
+            if t['highestBid'] is None:
+                self.log.critical("no bid price available")
+                self.disabled = True
+                return None
+            if t['lowestAsk'] is None or t['lowestAsk'] == 0.0:
+                self.log.critical("no ask price available")
+                self.disabled = True
+                return None
             bid = float(t['highestBid'])
             ask = float(t['lowestAsk'])
             return bid + ((ask - bid) * self.bot['start'] / 100.0)

--- a/dexbot/strategies/follow_orders.py
+++ b/dexbot/strategies/follow_orders.py
@@ -5,79 +5,143 @@ from bitshares.amount import Amount
 from bitshares.price import Price, Order, FilledOrder
 from dexbot.basestrategy import BaseStrategy, ConfigElement
 import time
-        
+
+
 class Strategy(BaseStrategy):
 
     @classmethod
     def configure(cls):
-        return BaseStrategy.configure()+[
-            ConfigElement("spread","float",5,"Percentage difference between buy and sell",(0,100)),
-            ConfigElement("wall","float",0.0,"the default amount to buy/sell, in quote",(0.0,None)),
-            ConfigElement("max","float",100.0,"bot will not trade if price above this",(0.0,None)),
-            ConfigElement("min","float",100.0,"bot will not trade if price below this",(0.0,None)),
-            ConfigElement("start","float",100.0,"Starting price, as percentage of bid/ask spread",(0.0,100.0)),
-            ConfigElement("reset","bool",False,"bot will alwys reset orders on start",(0.0,None)),
-            ConfigElement("staggers","int",1,"Number of additional staggered orders to place",(1,100)),
-            ConfigElement("staggerspread","float",5,"Percentage difference between staggered orders",(1,100))
+        return BaseStrategy.configure() + [
+            ConfigElement(
+                "spread",
+                "float",
+                5,
+                "Percentage difference between buy and sell",
+                (0,
+                 100)),
+            ConfigElement(
+                "wall",
+                "float",
+                0.0,
+                "the default amount to buy/sell, in quote",
+                (0.0,
+                 None)),
+            ConfigElement(
+                "max",
+                "float",
+                100.0,
+                "bot will not trade if price above this",
+                (0.0,
+                 None)),
+            ConfigElement(
+                "min",
+                "float",
+                100.0,
+                "bot will not trade if price below this",
+                (0.0,
+                 None)),
+            ConfigElement(
+                "start",
+                "float",
+                100.0,
+                "Starting price, as percentage of bid/ask spread",
+                (0.0,
+                 100.0)),
+            ConfigElement(
+                "reset",
+                "bool",
+                False,
+                "bot will alwys reset orders on start",
+                (0.0,
+                 None)),
+            ConfigElement(
+                "staggers",
+                "int",
+                1,
+                "Number of additional staggered orders to place",
+                (1,
+                 100)),
+            ConfigElement(
+                "staggerspread",
+                "float",
+                5,
+                "Percentage difference between staggered orders",
+                (1,
+                 100))
         ]
 
-
-    def safe_dissect(self,thing,name):
+    def safe_dissect(self, thing, name):
         try:
-            self.log.debug("%s() returned type: %r repr: %r dict: %r" % (name,type(thing),repr(thing),dict(thing)))
-        except:
-            self.log.debug("%s() returned type: %r repr: %r" % (name,type(thing),repr(thing)))
-
+            self.log.debug(
+                "%s() returned type: %r repr: %r dict: %r" %
+                (name, type(thing), repr(thing), dict(thing)))
+        except BaseException:
+            self.log.debug(
+                "%s() returned type: %r repr: %r" %
+                (name, type(thing), repr(thing)))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Define Callbacks
         self.onMarketUpdate += self.onmarket
-        if self.bot.get("reset",False):
+        if self.bot.get("reset", False):
             self.cancel_all()
         self.reassess()
-                                           
-    def updateorders(self,newprice):
+
+    def updateorders(self, newprice):
         """ Update the orders
         """
         self.log.info("Replacing orders. Baseprice is %f" % newprice)
         self['price'] = newprice
-        step1 = self.bot['spread']/200.0*newprice
-        step2 = self.bot['staggerspread']/100.0*newprice
+        step1 = self.bot['spread'] / 200.0 * newprice
+        step2 = self.bot['staggerspread'] / 100.0 * newprice
         # Canceling orders
         self.cancel_all()
-        # record balances
-        self.record_balances(newprice)
-        
+
         myorders = {}
 
         if newprice < self.bot["min"]:
             self.disabled = True
-            self.log.critical("Price %f is below minimum %f" % (newprice,self.bot["min"]))
-            return
+            self.log.critical(
+                "Price %f is below minimum %f" %
+                (newprice, self.bot["min"]))
+            return False
         if newprice > self.bot["max"]:
             self.disabled = True
-            self.log.critical("Price %f is above maximum %f" % (newprice,self.bot["max"]))
-            return
-        
-        if float(self.balance(self.market["quote"])) < self.bot["wall"]*self.bot['staggers']:
-            self.log.critical("insufficient sell balance: %r (needed %f)" % (self.balance(self.market["quote"]),self.bot["wall"]))
-            self.disabled = True # now we get no more events
-            return
+            self.log.critical(
+                "Price %f is above maximum %f" %
+                (newprice, self.bot["max"]))
+            return False
 
-        if self.balance(self.market["base"]) < newprice * self.bot["wall"] * self.bot['staggers']:
+        if float(self.balance(self.market["quote"])
+                 ) < self.bot["wall"] * self.bot['staggers']:
+            self.log.critical(
+                "insufficient sell balance: %r (needed %f)" %
+                (self.balance(
+                    self.market["quote"]),
+                    self.bot["wall"]))
+            self.disabled = True  # now we get no more events
+            return False
+
+        if self.balance(self.market["base"]) < newprice * \
+                self.bot["wall"] * self.bot['staggers']:
             self.disabled = True
-            self.log.critical("insufficient buy balance: %r (need: %f)" % (self.balance(self.market["base"]),self.bot["wall"]*buy_price))
-            return
-    
+            self.log.critical(
+                "insufficient buy balance: %r (need: %f)" %
+                (self.balance(
+                    self.market["base"]),
+                    self.bot["wall"] *
+                    buy_price))
+            return False
+
         amt = Amount(self.bot["wall"], self.market["quote"])
-        
-        sell_price = newprice+step1
-        for i in range(0,self.bot['staggers']):
-            self.log.info("SELL {amt} at {price} {base}/{quote} (= {inv_price} {quote}/{base})".format(
+
+        sell_price = newprice + step1
+        for i in range(0, self.bot['staggers']):
+            self.log.info("SELL {amt} at {price:.4g} {base}/{quote} (= {inv_price:.4g} {quote}/{base})".format(
                 amt=repr(amt),
                 price=sell_price,
-                inv_price = 1/sell_price,
+                inv_price=1 / sell_price,
                 quote=self.market['quote']['symbol'],
                 base=self.market['base']['symbol']))
             ret = self.market.sell(
@@ -89,13 +153,13 @@ class Strategy(BaseStrategy):
             self.log.debug("SELL order done")
             myorders[ret['orderid']] = sell_price
             sell_price += step2
-            
-        buy_price = newprice-step1
-        for i in range(0,self.bot['staggers']):
-            self.log.info("BUY {amt} at {price} {base}/{quote} (= {inv_price} {quote}/{base})".format(
+
+        buy_price = newprice - step1
+        for i in range(0, self.bot['staggers']):
+            self.log.info("BUY {amt} at {price:.4g} {base}/{quote} (= {inv_price:.4g} {quote}/{base})".format(
                 amt=repr(amt),
-                price = buy_price,
-                inv_price = 1/buy_price,
+                price=buy_price,
+                inv_price=1 / buy_price,
                 quote=self.market['quote']['symbol'],
                 base=self.market['base']['symbol']))
             ret = self.market.buy(
@@ -108,15 +172,21 @@ class Strategy(BaseStrategy):
             myorders[ret['orderid']] = buy_price
             buy_price -= step2
         self['myorders'] = myorders
-        #ret = self.execute() this doesn't seem to work reliably
-        #self.safe_dissect(ret,"execute")
+        # ret = self.execute() this doesn't seem to work reliably
+        # self.safe_dissect(ret,"execute")
 
+        return True
+    
     def onmarket(self, data):
-        if type(data) is FilledOrder and data['account_id'] == self.account['id']:
-            self.log.debug("data['quote']['asset'] = %r self.market['quote'] = %r" % (data['quote']['asset'],self.market['quote']))
+        if isinstance(
+                data, FilledOrder) and data['account_id'] == self.account['id']:
+            self.log.debug(
+                "data['quote']['asset'] = %r self.market['quote'] = %r" %
+                (data['quote']['asset'], self.market['quote']))
             if data['quote']['asset'] == self.market['quote']:
                 self.log.debug("Quote = quote")
-            if repr(data['quote']['asset']['id']) == repr(self.market['quote']['id']):
+            if repr(data['quote']['asset']['id']) == repr(
+                    self.market['quote']['id']):
                 self.log.debug("quote['id'] = quote['id']")
             self.reassess()
 
@@ -133,7 +203,7 @@ class Strategy(BaseStrategy):
             t = self.market.ticker()
             bid = float(t['highestBid'])
             ask = float(t['lowestAsk'])
-            self.updateorders(bid+((ask-bid)*self.bot['start']/100.0))
+            self.updateorders(bid + ((ask - bid) * self.bot['start'] / 100.0))
             time.sleep(1)
             self.reassess()
             return
@@ -142,12 +212,12 @@ class Strategy(BaseStrategy):
             found_price = 0.0
             highest_diff = 0.0
             for i in missing:
-                diff = fabs(self['price']-self['myorders'][i])
+                diff = fabs(self['price'] - self['myorders'][i])
                 if diff > highest_diff:
                     found_price = self['myorders'][i]
                     highest_diff = diff
-            self.updateorders(found_price)
-            time.sleep(1)
-            self.reassess() # check if order has been filled while we were busy entering orders
+            if self.updateorders(found_price):
+                time.sleep(1)
+                self.reassess()  # check if order has been filled while we were busy entering orders
         else:
             self.log.debug("nothing missing, no action")

--- a/dexbot/strategies/follow_orders.py
+++ b/dexbot/strategies/follow_orders.py
@@ -131,7 +131,7 @@ class Strategy(BaseStrategy):
                 (self.balance(
                     self.market["base"]),
                     self.bot["wall"] *
-                    buy_price))
+                    newprice))
             return False
 
         amt = Amount(self.bot["wall"], self.market["quote"])

--- a/dexbot/strategies/follow_orders.py
+++ b/dexbot/strategies/follow_orders.py
@@ -51,7 +51,7 @@ class Strategy(BaseStrategy):
                 "reset",
                 "bool",
                 False,
-                "bot will alwys reset orders on start",
+                "bot will always reset orders on start",
                 (0.0,
                  None)),
             ConfigElement(
@@ -106,22 +106,21 @@ class Strategy(BaseStrategy):
         if newprice < self.bot["min"]:
             self.disabled = True
             self.log.critical(
-                "Price %f is below minimum %f" %
-                (newprice, self.bot["min"]))
+                "Price {} is below minimum {}".format(
+                    newprice, self.bot["min"]))
             return False
         if newprice > self.bot["max"]:
             self.disabled = True
             self.log.critical(
-                "Price %f is above maximum %f" %
-                (newprice, self.bot["max"]))
+                "Price {} is above maximum {}".format(
+                    newprice, self.bot["max"]))
             return False
 
         if float(self.balance(self.market["quote"])
                  ) < self.bot["wall"] * self.bot['staggers']:
             self.log.critical(
-                "insufficient sell balance: %r (needed %f)" %
-                (self.balance(
-                    self.market["quote"]),
+                "insufficient sell balance: {} (needed {})".format(
+                    self.balance(self.market["quote"]),
                     self.bot["wall"]))
             self.disabled = True  # now we get no more events
             return False
@@ -130,11 +129,9 @@ class Strategy(BaseStrategy):
                 self.bot["wall"] * self.bot['staggers']:
             self.disabled = True
             self.log.critical(
-                "insufficient buy balance: %r (need: %f)" %
-                (self.balance(
-                    self.market["base"]),
-                    self.bot["wall"] *
-                    newprice))
+                "insufficient buy balance: {} (need: {})".format(
+                    self.balance(self.market["base"]),
+                    self.bot["wall"] * newprice))
             return False
 
         amt = Amount(self.bot["wall"], self.market["quote"])
@@ -184,8 +181,9 @@ class Strategy(BaseStrategy):
         if isinstance(
                 data, FilledOrder) and data['account_id'] == self.account['id']:
             self.log.debug(
-                "data['quote']['asset'] = %r self.market['quote'] = %r" %
-                (data['quote']['asset'], self.market['quote']))
+                "data['quote']['asset'] = {} self.market['quote'] = {}".format(
+                    data['quote']['asset'],
+                    self.market['quote']))
             if data['quote']['asset'] == self.market['quote']:
                 self.log.debug("Quote = quote")
             if repr(data['quote']['asset']['id']) == repr(
@@ -214,7 +212,7 @@ class Strategy(BaseStrategy):
         Returning None indicates no new orders
         """
         still_open = set(i['id'] for i in self.account.openorders)
-        self.log.debug("still_open: %r" % still_open)
+        self.log.debug("still_open: {}".format(still_open))
         if len(still_open) == 0:
             self.log.info("no open orders, recalculating the startprice")
             t = self.market.ticker()

--- a/docs/follow_orders.rst
+++ b/docs/follow_orders.rst
@@ -1,0 +1,84 @@
+**********************
+Follow Orders Strategy
+**********************
+
+This strategy places a buy and a sell walls into a specific market.
+It buys below a base price, and sells aboe the base price.
+
+It then reacts to orders filled (hence the name), when one order is
+completely filled, new walls are constructed using the filled order
+as the new base price.
+
+Configuration Questions
+=======================
+
+Spread
+------
+
+Percentage difference between buy and sell price. So a spread of 5% means the bot sells at 2.5%
+above the base price and buys 2.5% below.
+
+Wall
+----
+
+This is the "wall height": the default amount to buy/sell, in quote. So if you are on the AUD:BTS
+market, this is the amount to buy/sell in AUD.
+
+Max
+---
+
+The bot will stop trading if the base price goes above this value, it will shut down until you manually
+restart it. (i.e. it won't restart itself if the price drops)
+
+Remember prices are base/quote, so on AUD:BTS, that's the price of 1 AUD in BTS.
+
+Min
+---
+
+Same in reverse: stop running if prices go below this value.
+
+Start
+-----
+
+The initial base price, as a percentage of the settlement price. So "103" here means an initial base price 3%
+above the settlement price. (Yes I know not all BTS markets have a settlement price, currently the bot won't
+work in those)
+
+Reset
+-----
+
+Normally the bot checks if it has previously placed orders in the market and uses those. If true,
+this option forces the bot to cancel any existing orders when it starts up, and calculate
+the starting price from the settlement price as above.
+
+Staggers
+--------
+
+Number of additional (or "staggered") orders to place. By default this is "1" (so
+no additional orders). 2 or more means multiple sell and buy orders at different prices.
+
+Stagger Spread
+--------------
+
+The gap between each staggered order (as a percentage of the base price).
+
+So say the spread is 5%, staggers is "2", and "stagger spread" is 4%, then there will be 2
+buy orders: 2.5% and 6.5% (4% + 2.5%) below the base price, and two sells 2.5% and 6.5% above.
+The order amounts are all the same (see `wall` option).
+
+Bot problems
+============
+
+Like all liquidity bots, the bot really works best with a "even"
+market, i.e. where are are counterparties both buying and selling.
+
+With a severe "bear" market, the
+bot can be stuck being the sole participant that is still buying against panicked humans frantically selling.
+It repeatingly buys into the market and so it can
+run out of one asset quite quickly (although it will have bought it at
+lower and lower prices).
+
+I don't have a simple good solution (and happy to hear suggestions from experienced traders)
+
+I plan a smarter bot that will change its behaviour when it starts to runs low on an asset,
+but this will have a different name.

--- a/docs/follow_orders.rst
+++ b/docs/follow_orders.rst
@@ -18,11 +18,19 @@ Spread
 Percentage difference between buy and sell price. So a spread of 5% means the bot sells at 2.5%
 above the base price and buys 2.5% below.
 
-Wall
-----
+Wall Percent
+------------
 
-This is the "wall height": the default amount to buy/sell, in quote. So if you are on the AUD:BTS
-market, this is the amount to buy/sell in AUD.
+This is the "wall height": the default amount to buy/sell, expressed as a percentage of the account balance.
+So for sells, its that percentage of your balance of the 'quote' asset, and for buys
+its that same percentage of your balance of the 'base' asset.
+
+The advantage of this method (a change from early versions with 'fixed' wall heights) is it makes the bot 'self-correcting'
+if it sells to much of one asset, it will enter small orders for that asset, until the
+market gives it and opposing trade and it can rebalance itself.
+
+Remember if you are using 'staggers' (see below) each order is the same: so you probably need to use
+quite a small percentage here.
 
 Max
 ---
@@ -43,7 +51,7 @@ Start
 The initial price, as a percentage of the spread between the highest bid and lowest ask. So "0" means
 the highest bid, "100" means the lowest ask, 50 means the midpoint between them, and so on.
 
-*Important*: you need to look at the market and get a sense of its orderbook for setting this,
+*Important*: you need to look at your chosen market carefully and get a sense of its orderbook before setting this,
 justing setting "50" blind can lead to stupid prices especially in illiquid markets.
 
 Reset
@@ -66,7 +74,7 @@ The gap between each staggered order (as a percentage of the base price).
 
 So say the spread is 5%, staggers is "2", and "stagger spread" is 4%, then there will be 2
 buy orders: 2.5% and 6.5% (4% + 2.5%) below the base price, and two sells 2.5% and 6.5% above.
-The order amounts are all the same (see `wall` option).
+The order amounts are all the same (see `wall percent` option).
 
 Bot problems
 ============
@@ -75,12 +83,10 @@ Like all liquidity bots, the bot really works best with a "even"
 market, i.e. where are are counterparties both buying and selling.
 
 With a severe "bear" market, the
-bot can be stuck being the sole participant that is still buying against panicked humans frantically selling.
+bot can be stuck being the sole participant that is still buying against a herd of panicked humans frantically selling.
 It repeatingly buys into the market and so it can
 run out of one asset quite quickly (although it will have bought it at
 lower and lower prices).
 
 I don't have a simple good solution (and happy to hear suggestions from experienced traders)
 
-I plan a smarter bot that will change its behaviour when it starts to runs low on an asset,
-but this will have a different name.

--- a/docs/follow_orders.rst
+++ b/docs/follow_orders.rst
@@ -3,7 +3,7 @@ Follow Orders Strategy
 **********************
 
 This strategy places a buy and a sell walls into a specific market.
-It buys below a base price, and sells aboe the base price.
+It buys below a base price, and sells above the base price.
 
 It then reacts to orders filled (hence the name), when one order is
 completely filled, new walls are constructed using the filled order
@@ -40,16 +40,18 @@ Same in reverse: stop running if prices go below this value.
 Start
 -----
 
-The initial base price, as a percentage of the settlement price. So "103" here means an initial base price 3%
-above the settlement price. (Yes I know not all BTS markets have a settlement price, currently the bot won't
-work in those)
+The initial price, as a percentage of the spread between the highest bid and lowest ask. So "0" means
+the highest bid, "100" means the lowest ask, 50 means the midpoint between them, and so on.
+
+*Important*: you need to look at the market and get a sense of its orderbook for setting this,
+justing setting "50" blind can lead to stupid prices especially in illiquid markets.
 
 Reset
 -----
 
 Normally the bot checks if it has previously placed orders in the market and uses those. If true,
-this option forces the bot to cancel any existing orders when it starts up, and calculate
-the starting price from the settlement price as above.
+this option forces the bot to cancel any existing orders when it starts up, and re-calculate
+the starting price as above.
 
 Staggers
 --------


### PR DESCRIPTION
The "Follow Orders" bot. This is fundamentally the same as the liquidity "walls" in the original stakemachine, but battle-hardened after some (expensive) experiences running earlier versions on the AUD:BTS market.