### PR TITLE
Fast bot init

### DIFF
--- a/dexbot/bot.py
+++ b/dexbot/bot.py
@@ -34,9 +34,14 @@ class BotInfrastructure(threading.Thread):
 
         # BitShares instance
         self.bitshares = bitshares_instance or shared_bitshares_instance()
-
         self.config = config
-
+        self.view = view
+        
+    def init_bots(self):
+        """Do the actual initialisation of bots
+        Potentially quite slow (tens of seconds)
+        So called as part of run()
+        """
         # set the module search path
         user_bot_path = os.path.expanduser("~/bots")
         if os.path.exists(user_bot_path):
@@ -60,10 +65,10 @@ class BotInfrastructure(threading.Thread):
                     'Strategy'
                 )
                 self.bots[botname] = klass(
-                    config=config,
+                    config=self.config,
                     name=botname,
                     bitshares_instance=self.bitshares,
-                    view=view
+                    view=self.view
                 )
                 markets.add(bot['market'])
                 accounts.add(bot['account'])
@@ -125,6 +130,7 @@ class BotInfrastructure(threading.Thread):
                     self.bots[botname].log.exception(".onAccountUpdate()")
 
     def run(self):
+        self.init_bots()
         self.notify.listen()
 
     def stop(self):

--- a/dexbot/bot.py
+++ b/dexbot/bot.py
@@ -52,7 +52,7 @@ class BotInfrastructure(threading.Thread):
         markets = set()
         
         # Initialize bots:
-        for botname, bot in config["bots"].items():
+        for botname, bot in self.config["bots"].items():
             if "account" not in bot:
                 log_bots.critical("Bot has no account",extra={'botname':botname,'account':'unknown','market':'unknown','is_dsabled':(lambda: True)})
                 continue


### PR DESCRIPTION
With my follow orders bot, it establishes the first orders during its __init__() method.
This cna be quite slow (tens of seconds) if there are many orders. Currently this would be executed in BotInfrastructure.__init__, potentially in the main thread.
The slow parts of initialisation are now spun out into init_bots, called from BotInfrastructure.run(), so this will naturally occur in the background thread.