### PR TITLE
Write PID of the process

### DIFF
--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -58,13 +58,14 @@ def run(ctx):
     """ Continuously run the bot
     """
     if ctx.obj['pidfile']:
-        with open(ctx.obj['pidfile'],'w') as fd:
+        with open(ctx.obj['pidfile'], 'w') as fd:
             fd.write(str(os.getpid()))
     try:
         bot = BotInfrastructure(ctx.config)
         bot.run()
     except errors.NoBotsAvailable:
-        sys.exit(70) # 70= "Software error" in /usr/include/sysexts.h
+        sys.exit(70)  # 70= "Software error" in /usr/include/sysexts.h
+
 
 if __name__ == '__main__':
     main()

--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import logging
+import os
 import click
 import sys
 from .ui import (
@@ -34,6 +35,12 @@ logging.basicConfig(
     type=int,
     default=3,
     help='Verbosity (0-15)')
+@click.option(
+    '--pidfile',
+    '-p',
+    type=str,
+    default='',
+    help='File to write PID')
 @click.pass_context
 def main(ctx, **kwargs):
     ctx.obj = {}
@@ -50,6 +57,9 @@ def main(ctx, **kwargs):
 def run(ctx):
     """ Continuously run the bot
     """
+    if ctx.obj['pidfile']:
+        with open(ctx.obj['pidfile'],'w') as fd:
+            fd.write(str(os.getpid()))
     try:
         bot = BotInfrastructure(ctx.config)
         bot.run()

--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -61,8 +61,12 @@ def run(ctx):
         with open(ctx.obj['pidfile'], 'w') as fd:
             fd.write(str(os.getpid()))
     try:
-        bot = BotInfrastructure(ctx.config)
-        bot.run()
+        try:
+            bot = BotInfrastructure(ctx.config)
+            bot.run()
+        finally:
+            if ctx.obj['pidfile']:
+                os.unlink(ctx.obj['pidfile'])
     except errors.NoBotsAvailable:
         sys.exit(70)  # 70= "Software error" in /usr/include/sysexts.h
 


### PR DESCRIPTION
to an external files
when running the CLI dexbot as a daemon, this is necessary for some management systems.