### PR TITLE
Fix worker rename

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,0 @@
-node: wss://bitshares.openledger.info/ws
-
-workers: {}

--- a/dexbot/__init__.py
+++ b/dexbot/__init__.py
@@ -3,7 +3,7 @@ import os
 from appdirs import user_config_dir
 
 APP_NAME = "dexbot"
-VERSION = '0.1.15'
+VERSION = '0.1.16'
 AUTHOR = "codaone"
 __version__ = VERSION
 

--- a/dexbot/views/worker_item.py
+++ b/dexbot/views/worker_item.py
@@ -99,9 +99,8 @@ class WorkerItemWidget(QtWidgets.QWidget, Ui_widget):
         self.view.ui.add_worker_button.setEnabled(True)
 
     def reload_widget(self, worker_name):
-        """ Cancels orders of the widget's worker and then reloads the data of the widget
+        """ Reload the data of the widget
         """
-        self.main_ctrl.remove_worker(worker_name)
         self.worker_config = self.main_ctrl.get_worker_config(worker_name)
         self.setup_ui_data(self.worker_config)
         self._pause_worker()
@@ -114,6 +113,7 @@ class WorkerItemWidget(QtWidgets.QWidget, Ui_widget):
         # User clicked save
         if return_value:
             new_worker_name = edit_worker_dialog.worker_name
+            self.main_ctrl.remove_worker(self.worker_name)
             self.main_ctrl.replace_worker_config(self.worker_name, new_worker_name, edit_worker_dialog.worker_data)
             self.reload_widget(new_worker_name)
             self.worker_name = new_worker_name

--- a/dexbot/views/worker_item.py
+++ b/dexbot/views/worker_item.py
@@ -98,11 +98,11 @@ class WorkerItemWidget(QtWidgets.QWidget, Ui_widget):
         self.view.remove_worker_widget(self.worker_name)
         self.view.ui.add_worker_button.setEnabled(True)
 
-    def reload_widget(self, worker_name, new_worker_name):
+    def reload_widget(self, worker_name):
         """ Cancels orders of the widget's worker and then reloads the data of the widget
         """
         self.main_ctrl.remove_worker(worker_name)
-        self.worker_config = self.main_ctrl.get_worker_config(new_worker_name)
+        self.worker_config = self.main_ctrl.get_worker_config(worker_name)
         self.setup_ui_data(self.worker_config)
         self._pause_worker()
 
@@ -115,5 +115,5 @@ class WorkerItemWidget(QtWidgets.QWidget, Ui_widget):
         if return_value:
             new_worker_name = edit_worker_dialog.worker_name
             self.main_ctrl.replace_worker_config(self.worker_name, new_worker_name, edit_worker_dialog.worker_data)
-            self.reload_widget(self.worker_name, new_worker_name)
+            self.reload_widget(new_worker_name)
             self.worker_name = new_worker_name


### PR DESCRIPTION
Fixes a crash in GUI when renaming a worker
Also removes the unused config.yml from the project root