### PR TITLE
Errordialog

### DIFF
--- a/dexbot/controllers/main_controller.py
+++ b/dexbot/controllers/main_controller.py
@@ -3,6 +3,8 @@ import logging
 from dexbot import config_file
 from dexbot.worker import WorkerInfrastructure
 
+from dexbot.views.errors import PyQtHandler
+
 from ruamel.yaml import YAML
 from bitshares.instance import set_shared_bitshares_instance
 
@@ -22,6 +24,9 @@ class MainController:
         fh.setFormatter(formatter)
         logger.addHandler(fh)
         logger.setLevel(logging.INFO)
+        pyqth = PyQtHandler()
+        pyqth.setLevel(logging.ERROR)
+        logger.addHandler(pyqth)
 
     def create_worker(self, worker_name, config, view):
         # Todo: Add some threading here so that the GUI doesn't freeze

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -50,7 +50,7 @@ def verbose(f):
         ch.setFormatter(formatter1)
         logging.getLogger("dexbot").addHandler(ch)
         logging.getLogger("").handlers = []
-        
+
         # GrapheneAPI logging
         if ctx.obj["verbose"] > 4:
             verbosity = [
@@ -159,3 +159,19 @@ def confirmalert(msg):
         click.style("Alert", fg="red") +
         "] " + msg
     )
+
+# error message "translation"
+# here we convert some of the cryptic Graphene API error messages into a longer sentence
+# particularly whe the problem is something the user themselves can fix (such as not enough
+# money in account)
+# it's here because both GUI and CLI might use it
+
+
+TRANSLATIONS = {'amount_to_sell.amount > 0': "You need to have sufficient buy and sell amounts in your account"}
+
+
+def translate_error(err):
+    for k, v in TRANSLATIONS.items():
+        if k in err:
+            return v
+    return None

--- a/dexbot/views/create_wallet.py
+++ b/dexbot/views/create_wallet.py
@@ -1,5 +1,6 @@
 from .ui.create_wallet_window_ui import Ui_Dialog
 from .notice import NoticeDialog
+from .errors import guierror
 
 from PyQt5 import QtWidgets
 
@@ -13,6 +14,7 @@ class CreateWalletView(QtWidgets.QDialog):
         self.ui.setupUi(self)
         self.ui.ok_button.clicked.connect(self.validate_form)
 
+    @guierror
     def validate_form(self):
         password = self.ui.password_input.text()
         confirm_password = self.ui.confirm_password_input.text()

--- a/dexbot/views/create_worker.py
+++ b/dexbot/views/create_worker.py
@@ -1,5 +1,6 @@
 from .notice import NoticeDialog
 from .ui.create_worker_window_ui import Ui_Dialog
+from .errors import guierror
 
 from PyQt5 import QtWidgets
 
@@ -26,6 +27,7 @@ class CreateWorkerView(QtWidgets.QDialog):
         self.ui.relative_order_size_checkbox.stateChanged.connect(self.onchange_relative_order_size_checkbox)
         self.worker_data = {}
 
+    @guierror
     def onchange_relative_order_size_checkbox(self):
         checkbox = self.ui.relative_order_size_checkbox
         if checkbox.isChecked():
@@ -40,6 +42,7 @@ class CreateWorkerView(QtWidgets.QDialog):
             self.ui.amount_input.setMaximum(1000000000.000000)
             self.ui.amount_input.setValue(0.000000)
 
+    @guierror
     def onchange_center_price_dynamic_checkbox(self):
         checkbox = self.ui.center_price_dynamic_checkbox
         if checkbox.isChecked():
@@ -101,6 +104,7 @@ class CreateWorkerView(QtWidgets.QDialog):
         else:
             return True
 
+    @guierror
     def handle_save(self):
         if not self.validate_form():
             return

--- a/dexbot/views/edit_worker.py
+++ b/dexbot/views/edit_worker.py
@@ -1,6 +1,7 @@
 from .ui.edit_worker_window_ui import Ui_Dialog
 from .confirmation import ConfirmationDialog
 from .notice import NoticeDialog
+from .errors import guierror
 
 from PyQt5 import QtWidgets
 
@@ -44,7 +45,6 @@ class EditWorkerView(QtWidgets.QDialog, Ui_Dialog):
         self.save_button.clicked.connect(self.handle_save)
         self.cancel_button.clicked.connect(self.reject)
         self.center_price_dynamic_checkbox.stateChanged.connect(self.onchange_center_price_dynamic_checkbox)
-        self.center_price_dynamic_checkbox.stateChanged.connect(self.onchange_center_price_dynamic_checkbox)
         self.relative_order_size_checkbox.stateChanged.connect(self.onchange_relative_order_size_checkbox)
         self.worker_data = {}
 
@@ -62,6 +62,7 @@ class EditWorkerView(QtWidgets.QDialog, Ui_Dialog):
         input_field.setMaximum(1000000000.000000)
         input_field.setMinimumWidth(151)
 
+    @guierror
     def onchange_relative_order_size_checkbox(self):
         if self.relative_order_size_checkbox.isChecked():
             self.order_size_input_to_relative()
@@ -70,6 +71,7 @@ class EditWorkerView(QtWidgets.QDialog, Ui_Dialog):
             self.order_size_input_to_static()
             self.amount_input.setValue(0.000000)
 
+    @guierror
     def onchange_center_price_dynamic_checkbox(self):
         checkbox = self.center_price_dynamic_checkbox
         if checkbox.isChecked():
@@ -121,6 +123,7 @@ class EditWorkerView(QtWidgets.QDialog, Ui_Dialog):
                                     'Are you sure you want to do this?')
         return dialog.exec_()
 
+    @guierror
     def handle_save(self):
         if not self.validate_form():
             return

--- a/dexbot/views/errors.py
+++ b/dexbot/views/errors.py
@@ -1,0 +1,55 @@
+from PyQt5 import QtWidgets
+from PyQt5.Qt import QApplication
+
+import logging
+import traceback
+import sys
+
+from dexbot.ui import translate_error
+from dexbot.queue.idle_queue import idle_add
+
+class PyQtHandler(logging.Handler):
+    """
+    Logging handler for Py Qt events.
+    Based on Vinay Sajip's DBHandler class (http://www.red-dove.com/python_logging.html)
+    """
+    def emit(self, record):
+        # Use default formatting:
+        self.format(record)
+        message = record.msg
+        extra = translate_error(message)
+        if record.exc_info:
+            if not extra:
+                extra = translate_error(repr(record.exc_info[1]))
+            detail = logging._defaultFormatter.formatException(record.exc_info)
+        else:
+            detail = None
+        if hasattr(record, "worker_name"):
+            title = "Error on {}".format(record.worker_name)
+        else:
+            title = "DEXBot Error"
+        idle_add(showdialog, title, message, extra, detail)
+
+def guierror(func):
+    """A decorator for GUI handler functions - traps all exceptions and displays the dialog
+    """
+    def func_wrapper(obj, *args, **kwargs):
+        try:
+            return func(obj)
+        except BaseException as exc:
+            showdialog("DEXBot Error", "An error occurred with DEXBOT:   "+repr(exc), None, traceback.format_exc())
+            
+    return func_wrapper
+
+def showdialog(title, message, extra=None, detail=None):
+   msg = QtWidgets.QMessageBox()
+   msg.setIcon(QtWidgets.QMessageBox.Critical)
+   msg.setText(message)
+   if extra:
+       msg.setInformativeText(extra)
+   msg.setWindowTitle(title)
+   if detail:
+       msg.setDetailedText(detail)
+   msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
+	
+   msg.exec_()

--- a/dexbot/views/errors.py
+++ b/dexbot/views/errors.py
@@ -8,11 +8,13 @@ import sys
 from dexbot.ui import translate_error
 from dexbot.queue.idle_queue import idle_add
 
+
 class PyQtHandler(logging.Handler):
     """
     Logging handler for Py Qt events.
     Based on Vinay Sajip's DBHandler class (http://www.red-dove.com/python_logging.html)
     """
+
     def emit(self, record):
         # Use default formatting:
         self.format(record)
@@ -30,6 +32,7 @@ class PyQtHandler(logging.Handler):
             title = "DEXBot Error"
         idle_add(showdialog, title, message, extra, detail)
 
+
 def guierror(func):
     """A decorator for GUI handler functions - traps all exceptions and displays the dialog
     """
@@ -38,18 +41,19 @@ def guierror(func):
             return func(obj)
         except BaseException as exc:
             showdialog("DEXBot Error", "An error occurred with DEXBOT:   "+repr(exc), None, traceback.format_exc())
-            
+
     return func_wrapper
 
+
 def showdialog(title, message, extra=None, detail=None):
-   msg = QtWidgets.QMessageBox()
-   msg.setIcon(QtWidgets.QMessageBox.Critical)
-   msg.setText(message)
-   if extra:
-       msg.setInformativeText(extra)
-   msg.setWindowTitle(title)
-   if detail:
-       msg.setDetailedText(detail)
-   msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
-	
-   msg.exec_()
+    msg = QtWidgets.QMessageBox()
+    msg.setIcon(QtWidgets.QMessageBox.Critical)
+    msg.setText(message)
+    if extra:
+        msg.setInformativeText(extra)
+    msg.setWindowTitle(title)
+    if detail:
+        msg.setDetailedText(detail)
+    msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
+
+    msg.exec_()

--- a/dexbot/views/unlock_wallet.py
+++ b/dexbot/views/unlock_wallet.py
@@ -1,6 +1,7 @@
 from .ui.unlock_wallet_window_ui import Ui_Dialog
 from .notice import NoticeDialog
 from .errors import guierror
+
 from PyQt5 import QtWidgets
 
 

--- a/dexbot/views/unlock_wallet.py
+++ b/dexbot/views/unlock_wallet.py
@@ -1,6 +1,6 @@
 from .ui.unlock_wallet_window_ui import Ui_Dialog
 from .notice import NoticeDialog
-
+from .errors import guierror
 from PyQt5 import QtWidgets
 
 
@@ -13,6 +13,7 @@ class UnlockWalletView(QtWidgets.QDialog):
         self.ui.setupUi(self)
         self.ui.ok_button.clicked.connect(self.validate_form)
 
+    @guierror
     def validate_form(self):
         password = self.ui.password_input.text()
         if not self.controller.unlock_wallet(password):

--- a/dexbot/views/worker_item.py
+++ b/dexbot/views/worker_item.py
@@ -4,6 +4,8 @@ from .edit_worker import EditWorkerView
 from dexbot.storage import db_worker
 from dexbot.controllers.create_worker_controller import CreateWorkerController
 
+from dexbot.views.errors import guierror
+
 from PyQt5 import QtWidgets
 
 
@@ -47,6 +49,7 @@ class WorkerItemWidget(QtWidgets.QWidget, Ui_widget):
         else:
             self.set_worker_slider(50)
 
+    @guierror
     def start_worker(self):
         self._start_worker()
         self.main_ctrl.create_worker(self.worker_name, self.worker_config, self.view)
@@ -56,6 +59,7 @@ class WorkerItemWidget(QtWidgets.QWidget, Ui_widget):
         self.pause_button.show()
         self.play_button.hide()
 
+    @guierror
     def pause_worker(self):
         self._pause_worker()
         self.main_ctrl.stop_worker(self.worker_name)
@@ -85,6 +89,7 @@ class WorkerItemWidget(QtWidgets.QWidget, Ui_widget):
     def set_worker_slider(self, value):
         self.order_slider.setSliderPosition(value)
 
+    @guierror
     def remove_widget_dialog(self):
         dialog = ConfirmationDialog('Are you sure you want to remove worker "{}"?'.format(self.worker_name))
         return_value = dialog.exec_()
@@ -105,6 +110,7 @@ class WorkerItemWidget(QtWidgets.QWidget, Ui_widget):
         self.setup_ui_data(self.worker_config)
         self._pause_worker()
 
+    @guierror
     def handle_edit_worker(self):
         controller = CreateWorkerController(self.main_ctrl)
         edit_worker_dialog = EditWorkerView(controller, self.worker_name, self.worker_config)

--- a/dexbot/views/worker_item.py
+++ b/dexbot/views/worker_item.py
@@ -3,7 +3,6 @@ from .confirmation import ConfirmationDialog
 from .edit_worker import EditWorkerView
 from dexbot.storage import db_worker
 from dexbot.controllers.create_worker_controller import CreateWorkerController
-
 from dexbot.views.errors import guierror
 
 from PyQt5 import QtWidgets

--- a/dexbot/views/worker_list.py
+++ b/dexbot/views/worker_list.py
@@ -11,6 +11,7 @@ from dexbot.queue.idle_queue import idle_add
 
 from PyQt5 import QtWidgets
 from bitsharesapi.bitsharesnoderpc import BitSharesNodeRPC
+from .errors import guierror
 
 
 class MainView(QtWidgets.QMainWindow):
@@ -69,6 +70,7 @@ class MainView(QtWidgets.QMainWindow):
         if self.num_of_workers < self.max_workers:
             self.ui.add_worker_button.setEnabled(True)
 
+    @guierror
     def handle_add_worker(self):
         controller = CreateWorkerController(self.main_ctrl)
         create_worker_dialog = CreateWorkerView(controller)

--- a/dexbot/views/worker_list.py
+++ b/dexbot/views/worker_list.py
@@ -8,10 +8,10 @@ from .worker_item import WorkerItemWidget
 from dexbot.controllers.create_worker_controller import CreateWorkerController
 from dexbot.queue.queue_dispatcher import ThreadDispatcher
 from dexbot.queue.idle_queue import idle_add
+from .errors import guierror
 
 from PyQt5 import QtWidgets
 from bitsharesapi.bitsharesnoderpc import BitSharesNodeRPC
-from .errors import guierror
 
 
 class MainView(QtWidgets.QMainWindow):


### PR DESCRIPTION
addressed issue #36 with the standard QMessageBox displayed whenver an exception happened, teither in GUI code or in the worker layer.
The full python stacktrace is available as "Details" in the Qt dialog.
Provision for adding comments to some of the more cryptic graphene eror messages (intended for where the user can fix, such as insufficient account funds or broken Internet connection)