### PR TITLE
detect the graphene error "Assert Exception: now <= trx.expiration"

### DIFF
--- a/dexbot/basestrategy.py
+++ b/dexbot/basestrategy.py
@@ -445,5 +445,13 @@ class BaseStrategy(Storage, StateMachine, Events):
                         self.bitshares.txbuffer.clear()
                         self.account.refresh()
                         time.sleep(2)
+                elif "now <= trx.expiration" in str(e):  # usually loss of sync to blockchain
+                    if tries > MAX_TRIES:
+                        raise
+                    else:
+                        tries += 1
+                        self.log.warning("retrying on '{}'".format(str(e)))
+                        self.bitshares.txbuffer.clear()
+                        time.sleep(6)  # wait at least a BitShares block
                 else:
                     raise

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -167,7 +167,8 @@ def confirmalert(msg):
 # it's here because both GUI and CLI might use it
 
 
-TRANSLATIONS = {'amount_to_sell.amount > 0': "You need to have sufficient buy and sell amounts in your account"}
+TRANSLATIONS = {'amount_to_sell.amount > 0': "You need to have sufficient buy and sell amounts in your account",
+                'now <= trx.expiration': "Your node has difficulty syncing to the blockchain, consider changing nodes"}
 
 
 def translate_error(err):


### PR DESCRIPTION
which usually represents the node being unable to sync the blockchain
do a number of retries
and display an explanation on the GUI