### PR TITLE
Improve Relative Orders spread calculation

### DIFF
--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -62,7 +62,7 @@ class Strategy(BaseStrategy):
         if self.is_center_price_dynamic:
             self.center_price = self.calculate_relative_center_price(self.worker['spread'], self['order_ids'])
 
-        self.buy_price = self.center_price * (1 - (self.worker["spread"] / 2) / 100)
+        self.buy_price = self.center_price / (1 + (self.worker["spread"] / 2) / 100)
         self.sell_price = self.center_price * (1 + (self.worker["spread"] / 2) / 100)
 
     def error(self, *args, **kwargs):

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -2,6 +2,7 @@ from dexbot.basestrategy import BaseStrategy
 from dexbot.queue.idle_queue import idle_add
 
 from bitshares.amount import Amount
+import math
 
 
 class Strategy(BaseStrategy):
@@ -62,8 +63,8 @@ class Strategy(BaseStrategy):
         if self.is_center_price_dynamic:
             self.center_price = self.calculate_relative_center_price(self.worker['spread'], self['order_ids'])
 
-        self.buy_price = self.center_price / (1 + (self.worker["spread"] / 2) / 100)
-        self.sell_price = self.center_price * (1 + (self.worker["spread"] / 2) / 100)
+        self.buy_price = self.center_price / math.sqrt(1 + (self.worker["spread"] / 100))
+        self.sell_price = self.center_price * math.sqrt(1 + (self.worker["spread"] / 100))
 
     def error(self, *args, **kwargs):
         self.cancel_all()


### PR DESCRIPTION
With this fix, buy and sell orders should be placed at exactly the same price points regardless of which way the market is looked at. That is, the prices should be the same when:
1. Prices are calculated and market flipped upside-down, and 
2. Market is flipped first, and then prices calculated.

This fix reduces the slight bias towards selling. It also makes huge spread's calculation work better.