### PR TITLE
Leave staggered orders when exiting from dexbot-cli

### DIFF
--- a/dexbot/basestrategy.py
+++ b/dexbot/basestrategy.py
@@ -333,6 +333,12 @@ class BaseStrategy(Storage, StateMachine, Events):
             self.cancel(self.orders)
         self.log.info("Orders canceled")
 
+    def clean_exit(self):
+        """ Worker stop/exit wrapper. It should perform cleanup actions when terminating the bot.
+            By default, just call cancel_all().
+        """
+        self.cancel_all()
+
     def market_buy(self, amount, price, return_none=False):
         symbol = self.market['base']['symbol']
         precision = self.market['base']['precision']

--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -64,7 +64,7 @@ def run(ctx):
         try:
             worker = WorkerInfrastructure(ctx.config)
             # Set up signalling. do it here as of no relevance to GUI
-            kill_workers = worker_job(worker, worker.stop)
+            kill_workers = worker_job(worker, worker.clean_exit)
             # These first two UNIX & Windows
             signal.signal(signal.SIGTERM, kill_workers)
             signal.signal(signal.SIGINT, kill_workers)

--- a/dexbot/strategies/staggered_orders.py
+++ b/dexbot/strategies/staggered_orders.py
@@ -42,6 +42,9 @@ class Strategy(BaseStrategy):
         self.cancel_all()
         self.disabled = True
 
+    def clean_exit(self):
+        self.log.info("Performing clean exit, leaving orders")
+
     def init_strategy(self):
         # Make sure no orders remain
         self.cancel_all()


### PR DESCRIPTION
1. Change how INT/HUP/TERM signals are being handled. Instead of
invoking worker.stop job, define a separate worker.clean_exit job which
actually do the same things as stop(), but instead of cancel_all() it
calls clean_exit() method. Thus, each strategy can separately define how
it should handle exit signals.

2. In staggered_orders.py strategy define clean_exit() method which
doesn't cancel orders but leaves them.

3. Because of (2), staggered_orders.py at the every worker startup
should not try to place any orders from database. Since previous run
things on the marked may drastically change and just placing old orders
is just an error. So, just recalculate everything after worker startup
and place newly calculated orders.

Closes: #137