### PR TITLE
Fix logic in staggered orders maintenance

### DIFF
--- a/dexbot/basestrategy.py
+++ b/dexbot/basestrategy.py
@@ -333,6 +333,12 @@ class BaseStrategy(Storage, StateMachine, Events):
             self.cancel(self.orders)
         self.log.info("Orders canceled")
 
+    def pause(self):
+        """ Pause worker. User presed "pause" button in the GUI
+        """
+        # By default, just call cancel_all(); strategies may override this method
+        self.cancel_all()
+
     def market_buy(self, amount, price, return_none=False):
         symbol = self.market['base']['symbol']
         precision = self.market['base']['precision']

--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -64,7 +64,7 @@ def run(ctx):
         try:
             worker = WorkerInfrastructure(ctx.config)
             # Set up signalling. do it here as of no relevance to GUI
-            kill_workers = worker_job(worker, worker.stop)
+            kill_workers = worker_job(worker, worker.pause)
             # These first two UNIX & Windows
             signal.signal(signal.SIGTERM, kill_workers)
             signal.signal(signal.SIGINT, kill_workers)

--- a/dexbot/controllers/main_controller.py
+++ b/dexbot/controllers/main_controller.py
@@ -46,6 +46,9 @@ class MainController:
     def stop_worker(self, worker_name):
         self.worker_manager.stop(worker_name)
 
+    def pause_worker(self, worker_name):
+        self.worker_manager.pause(worker_name)
+
     def remove_worker(self, worker_name):
         # Todo: Add some threading here so that the GUI doesn't freeze
         if self.worker_manager and self.worker_manager.is_alive():

--- a/dexbot/strategies/staggered_orders.py
+++ b/dexbot/strategies/staggered_orders.py
@@ -100,6 +100,11 @@ class Strategy(BaseStrategy):
         self['setup_done'] = True
         self.log.info("Done placing orders")
 
+    def pause(self, *args, **kwargs):
+        """ Override pause() method because we don't want to remove orders
+        """
+        self.log.info("Got pause command, stopping and leaving orders on the market")
+
     def place_reverse_order(self, order):
         """ Replaces an order with a reverse order
             buy orders become sell orders and sell orders become buy orders

--- a/dexbot/strategies/staggered_orders.py
+++ b/dexbot/strategies/staggered_orders.py
@@ -30,7 +30,7 @@ class Strategy(BaseStrategy):
         self.lower_bound = self.worker['lower_bound']
 
         if self['setup_done']:
-            self.place_orders()
+            self.check_orders()
         else:
             self.init_strategy()
 
@@ -133,6 +133,7 @@ class Strategy(BaseStrategy):
 
     def place_orders(self):
         """ Place all the orders found in the database
+            FIXME: unused method
         """
         orders = self.fetch_orders()
         for order_id, order in orders.items():

--- a/dexbot/views/worker_item.py
+++ b/dexbot/views/worker_item.py
@@ -68,7 +68,7 @@ class WorkerItemWidget(QtWidgets.QWidget, Ui_widget):
     def pause_worker(self):
         self.set_status("Pausing worker")
         self._pause_worker()
-        self.main_ctrl.stop_worker(self.worker_name)
+        self.main_ctrl.pause_worker(self.worker_name)
 
     def _pause_worker(self):
         self.running = False


### PR DESCRIPTION
Actual behavior
===========

In the staggered orders strategy we have a following logic at the initialization:

```python
        if self['setup_done']:
            self.place_orders()
        else:
            self.init_strategy()

```

By this logic a fresh worker will do `self.init_strategy()`. It will:
1. Create a market orders
2. Save orders to the database

Next, we're stopped worker and let it be offline. During this time some orders will be filled.

Next, we're starting worker again. This time `self.place_orders()` will be executed. This means **bot will  place already filled orders again** likely causing an error `Insufficient buy/sell balance`:

```python
    def place_orders(self):
        """ Place all the orders found in the database
        """
        orders = self.fetch_orders()
        for order_id, order in orders.items():
            if not self.get_order(order_id):
                self.place_order(order)
```

Expected behavior
=============

Instead of trying to repeat already filled order bot must place a reverse order. The logic I expect:

1. Init strategy, place orders, save them to the dadabase
2. Put bot offline
3. Let orders fill
4. Start worker
5. Worker fetches orders from database and check whether they exists on the market
6. Order found in the database but not present in the orderbook. Causes? Order was cancelled manually or filled. Assume we should not manually touch bot's order. Then, the only way order disappeared is that it was filled!
7. So we know order was filled, so place reverse order.

Closes: #160