### PR TITLE
Do not cancel orders on error for staggered strategy

### DIFF
--- a/dexbot/strategies/staggered_orders.py
+++ b/dexbot/strategies/staggered_orders.py
@@ -41,7 +41,6 @@ class Strategy(BaseStrategy):
             self.update_gui_slider()
 
     def error(self, *args, **kwargs):
-        self.cancel_all()
         self.disabled = True
 
     def init_strategy(self):


### PR DESCRIPTION
Orders should not be cancelled on error because on next run reverse
orders will be placed effectively selling all your funds.

Closes: #170