### PR TITLE
Set high order expiration time for staggered orders

### DIFF
--- a/dexbot/basestrategy.py
+++ b/dexbot/basestrategy.py
@@ -347,7 +347,7 @@ class BaseStrategy(Storage, StateMachine, Events):
         # By default, just call cancel_all(); strategies may override this method
         self.cancel_all()
 
-    def market_buy(self, amount, price, return_none=False):
+    def market_buy(self, amount, price, return_none=False, *args, **kwargs):
         symbol = self.market['base']['symbol']
         precision = self.market['base']['precision']
         base_amount = self.truncate(price * amount, precision)
@@ -372,7 +372,9 @@ class BaseStrategy(Storage, StateMachine, Events):
             price,
             Amount(amount=amount, asset=self.market["quote"]),
             account=self.account.name,
-            returnOrderId="head"
+            returnOrderId="head",
+            *args,
+            **kwargs
         )
         self.log.debug('Placed buy order {}'.format(buy_transaction))
         buy_order = self.get_order(buy_transaction['orderid'], return_none=return_none)
@@ -384,7 +386,7 @@ class BaseStrategy(Storage, StateMachine, Events):
 
         return buy_order
 
-    def market_sell(self, amount, price, return_none=False):
+    def market_sell(self, amount, price, return_none=False, *args, **kwargs):
         symbol = self.market['quote']['symbol']
         precision = self.market['quote']['precision']
         quote_amount = self.truncate(amount, precision)
@@ -409,7 +411,9 @@ class BaseStrategy(Storage, StateMachine, Events):
             price,
             Amount(amount=amount, asset=self.market["quote"]),
             account=self.account.name,
-            returnOrderId="head"
+            returnOrderId="head",
+            *args,
+            **kwargs
         )
         self.log.debug('Placed sell order {}'.format(sell_transaction))
         sell_order = self.get_order(sell_transaction['orderid'], return_none=return_none)

--- a/dexbot/strategies/staggered_orders.py
+++ b/dexbot/strategies/staggered_orders.py
@@ -28,6 +28,8 @@ class Strategy(BaseStrategy):
         self.increment = self.worker['increment'] / 100
         self.upper_bound = self.worker['upper_bound']
         self.lower_bound = self.worker['lower_bound']
+        # Order expiration time, should be high enough
+        self.expiration = 60*60*24*365*5
 
         if self['setup_done']:
             self.check_orders()
@@ -89,13 +91,13 @@ class Strategy(BaseStrategy):
 
         # Place the buy orders
         for buy_order in buy_orders:
-            order = self.market_buy(buy_order['amount'], buy_order['price'])
+            order = self.market_buy(buy_order['amount'], buy_order['price'], expiration=self.expiration)
             if order:
                 self.save_order(order)
 
         # Place the sell orders
         for sell_order in sell_orders:
-            order = self.market_sell(sell_order['amount'], sell_order['price'])
+            order = self.market_sell(sell_order['amount'], sell_order['price'], expiration=self.expiration)
             if order:
                 self.save_order(order)
 
@@ -114,11 +116,11 @@ class Strategy(BaseStrategy):
         if order['base']['symbol'] == self.market['base']['symbol']:  # Buy order
             price = order['price'] * (1 + self.spread)
             amount = order['quote']['amount']
-            new_order = self.market_sell(amount, price)
+            new_order = self.market_sell(amount, price, expiration=self.expiration)
         else:  # Sell order
             price = (order['price'] ** -1) / (1 + self.spread)
             amount = order['base']['amount']
-            new_order = self.market_buy(amount, price)
+            new_order = self.market_buy(amount, price, expiration=self.expiration)
 
         if new_order:
             self.remove_order(order)
@@ -130,11 +132,11 @@ class Strategy(BaseStrategy):
         if order['base']['symbol'] == self.market['base']['symbol']:  # Buy order
             price = order['price']
             amount = order['quote']['amount']
-            new_order = self.market_buy(amount, price)
+            new_order = self.market_buy(amount, price, expiration=self.expiration)
         else:  # Sell order
             price = order['price'] ** -1
             amount = order['base']['amount']
-            new_order = self.market_sell(amount, price)
+            new_order = self.market_sell(amount, price, expiration=self.expiration)
 
         self.save_order(new_order)
 


### PR DESCRIPTION
By default, dexbot uses python-bitshares order expiration time (7 days)
which is quite low for staggered orders. Whether order expired, on the
next run of the staggered orders worker it will treat expired order as
filled and so a reverse order will be placed, effectively selling your
funds (same as #170).

Closes: #174