### PR TITLE
Fix duplicate private key error

### DIFF
--- a/dexbot/basestrategy.py
+++ b/dexbot/basestrategy.py
@@ -496,8 +496,8 @@ class BaseStrategy(Storage, StateMachine, Events):
     def purge(self):
         """ Clear all the worker data from the database and cancel all orders
         """
-        self.cancel_all()
         self.clear_orders()
+        self.cancel_all()
         self.clear()
 
     @staticmethod

--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -108,6 +108,9 @@ def run(ctx):
 
 @main.command()
 @click.pass_context
+@configfile
+@chain
+@unlock
 def configure(ctx):
     """ Interactively configure dexbot
     """
@@ -117,7 +120,7 @@ def configure(ctx):
         os.system('systemctl --user stop dexbot')
 
     config = Config(path=ctx.obj['configfile'])
-    configure_dexbot(config)
+    configure_dexbot(config, ctx)
     config.save_config()
 
     click.echo("New configuration saved")

--- a/dexbot/cli_conf.py
+++ b/dexbot/cli_conf.py
@@ -179,7 +179,7 @@ def configure_worker(d, worker):
     return worker
 
 
-def configure_dexbot(config):
+def configure_dexbot(config, ctx):
     d = get_whiptail()
     workers = config.get('workers', {})
     if not workers:
@@ -190,21 +190,23 @@ def configure_dexbot(config):
                 break
         setup_systemd(d, config)
     else:
+        bitshares_instance = ctx.bitshares
         action = d.menu("You have an existing configuration.\nSelect an action:",
                         [('NEW', 'Create a new worker'),
                          ('DEL', 'Delete a worker'),
                          ('EDIT', 'Edit a worker'),
                          ('CONF', 'Redo general config')])
+
         if action == 'EDIT':
             worker_name = d.menu("Select worker to edit", [(i, i) for i in workers])
             config['workers'][worker_name] = configure_worker(d, config['workers'][worker_name])
-            bitshares_instance = BitShares(config['node'])
+
             strategy = BaseStrategy(worker_name, bitshares_instance=bitshares_instance)
             strategy.purge()
         elif action == 'DEL':
             worker_name = d.menu("Select worker to delete", [(i, i) for i in workers])
             del config['workers'][worker_name]
-            bitshares_instance = BitShares(config['node'])
+
             strategy = BaseStrategy(worker_name, bitshares_instance=bitshares_instance)
             strategy.purge()
         elif action == 'NEW':

--- a/dexbot/controllers/main_controller.py
+++ b/dexbot/controllers/main_controller.py
@@ -59,14 +59,13 @@ class MainController:
             else:
                 # Worker not running
                 config = self.config.get_worker_config(worker_name)
-                WorkerInfrastructure.remove_offline_worker(config, worker_name)
+                WorkerInfrastructure.remove_offline_worker(config, worker_name, self.bitshares_instance)
         else:
             # Worker manager not running
             config = self.config.get_worker_config(worker_name)
-            WorkerInfrastructure.remove_offline_worker(config, worker_name)
+            WorkerInfrastructure.remove_offline_worker(config, worker_name, self.bitshares_instance)
 
     @staticmethod
     def create_worker(worker_name):
         # Deletes old worker's data
         WorkerInfrastructure.remove_offline_worker_data(worker_name)
-

--- a/dexbot/views/worker_item.py
+++ b/dexbot/views/worker_item.py
@@ -3,11 +3,9 @@ import re
 from .ui.worker_item_widget_ui import Ui_widget
 from .confirmation import ConfirmationDialog
 from .edit_worker import EditWorkerView
-from .errors import gui_error
 from dexbot.storage import db_worker
 from dexbot.controllers.worker_controller import WorkerController
 from dexbot.views.errors import gui_error
-from dexbot.resources import icons_rc
 
 from PyQt5 import QtCore, QtWidgets
 
@@ -141,7 +139,10 @@ class WorkerItemWidget(QtWidgets.QWidget, Ui_widget):
             self.remove_widget()
 
     def remove_widget(self):
+        account = self.worker_config['workers'][self.worker_name]['account']
+
         self.main_ctrl.remove_worker(self.worker_name)
+        self.main_ctrl.bitshares_instance.wallet.removeAccount(account)
         self.view.remove_worker_widget(self.worker_name)
         self.main_ctrl.config.remove_worker_config(self.worker_name)
         self.deleteLater()

--- a/dexbot/worker.py
+++ b/dexbot/worker.py
@@ -223,9 +223,8 @@ class WorkerInfrastructure(threading.Thread):
                 self.markets.remove(market)
 
     @staticmethod
-    def remove_offline_worker(config, worker_name):
+    def remove_offline_worker(config, worker_name, bitshares_instance):
         # Initialize the base strategy to get control over the data
-        bitshares_instance = BitShares(config['node'])
         strategy = BaseStrategy(worker_name, config, bitshares_instance=bitshares_instance)
         strategy.purge()
 


### PR DESCRIPTION
Fix problem where old private key was not deleted and caused an error when adding new worker. Also fixed wallet locked error. Closes #210