### PR TITLE
asset names can have dots

### DIFF
--- a/dexbot/basestrategy.py
+++ b/dexbot/basestrategy.py
@@ -102,7 +102,7 @@ class BaseStrategy(Storage, StateMachine, Events):
             ConfigElement("account", "string", "", "BitShares account name for the bot to operate with", ""),
             ConfigElement("market", "string", "USD:BTS",
                           "BitShares market to operate on, in the format ASSET:OTHERASSET, for example \"USD:BTS\"",
-                          "[A-Z]+[:\/][A-Z]+")
+                          r"[A-Z\.]+[:\/][A-Z\.]+")
         ]
 
     def __init__(


### PR DESCRIPTION
I forgot asset names have dots, like `OPEN.BTC` Several people on telegram have complained the CLI installer won't let them create workers for these assets as the name can't pass the regular expression.