### PR TITLE
Pass num_retries to bitshares instance for cli

### DIFF
--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -78,6 +78,7 @@ def chain(f):
     def new_func(ctx, *args, **kwargs):
         ctx.bitshares = BitShares(
             ctx.config["node"],
+            num_retries=-1,
             **ctx.obj
         )
         set_shared_bitshares_instance(ctx.bitshares)


### PR DESCRIPTION
Fixes exceptions during handling on_market callbacks.