### PR TITLE
Reset on_block callback during worker stop

### DIFF
--- a/dexbot/worker.py
+++ b/dexbot/worker.py
@@ -201,7 +201,8 @@ class WorkerInfrastructure(threading.Thread):
                 for worker in self.workers:
                     self.workers[worker].pause()
             if self.notify:
-                self.notify.websocket.close()
+                self.notify.close()
+                self.notify.on_block = None
 
     def remove_worker(self, worker_name=None):
         if worker_name:


### PR DESCRIPTION
on_block event comes from Notify instance even after
self.notify.websocket.close(), this is the simply workaround.

Closes: #257