### PR TITLE
Remove CLI compiling from releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,10 @@ install:
 script:
   - echo "@TODO - Running tests..."
   - pyinstaller --distpath dist/$TRAVIS_OS_NAME gui.spec
-  - pyinstaller --distpath dist/$TRAVIS_OS_NAME cli.spec
 before_deploy:
   - git config --local user.name "Travis"
   - git config --local user.email "travis@travis-ci.org"
   - git tag "$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)"
-  - tar -czvf dist/DEXBot-cli-$TRAVIS_OS_NAME-$TRAVIS_TAG.tar.gz dist/$TRAVIS_OS_NAME/DEXBot-cli
   - tar -czvf dist/DEXBot-gui-$TRAVIS_OS_NAME-$TRAVIS_TAG.tar.gz dist/$TRAVIS_OS_NAME/DEXBot-gui
 deploy:
   - provider: releases

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
     - PYTHON: "C:\\Python35-x64"
 
 #---------------------------------#
-#        build                    #
+#        Build                    #
 #---------------------------------#
 
 build: off
@@ -24,7 +24,6 @@ install:
 
 after_test:
   - make package
-  - '7z a DEXBot-cli-win64.zip %APPVEYOR_BUILD_FOLDER%\dist\DEXBot-cli.exe'
   - '7z a DEXBot-gui-win64.zip %APPVEYOR_BUILD_FOLDER%\dist\DEXBot-gui.exe'
 
 # @TODO: Run tests..
@@ -32,14 +31,11 @@ test_script:
   - "echo tests..."
 
 artifacts:
-  - path: DEXBot-cli-win64.zip
-    name: DEXBot-cli-win64.zip
-
   - path: DEXBot-gui-win64.zip
     name: DEXBot-gui-win64.zip
 
 #---------------------------------#
-#        deployment               #
+#        Deployment               #
 #---------------------------------#
 
 shallow_clone: false
@@ -57,7 +53,7 @@ deploy:
       appveyor_repo_tag: true     # deploy on tag push only
 
 #---------------------------------#
-#         notifications           #
+#         Notifications           #
 #---------------------------------#
 
 notifications:


### PR DESCRIPTION
Since _nobody_ uses the compiled CLI files, it's better to remove the compiling to speed up travis and appveyor run speed