### PR TITLE
Implement different triggers to reset orders

### DIFF
--- a/dexbot/controllers/strategy_controller.py
+++ b/dexbot/controllers/strategy_controller.py
@@ -93,12 +93,30 @@ class RelativeOrdersController(StrategyController):
         self.view.strategy_widget.center_price_dynamic_input.toggled.connect(
             self.onchange_center_price_dynamic_input
         )
+        self.view.strategy_widget.reset_on_partial_fill_input.toggled.connect(
+            self.onchange_reset_on_partial_fill_input
+        )
+        self.view.strategy_widget.reset_on_price_change_input.toggled.connect(
+            self.onchange_reset_on_price_change_input
+        )
+        self.view.strategy_widget.custom_expiration_input.toggled.connect(
+            self.onchange_custom_expiration_input
+        )
 
         # Do this after the event connecting
         super().__init__(view, configure, worker_controller, worker_data)
 
         if not self.view.strategy_widget.center_price_dynamic_input.isChecked():
             self.view.strategy_widget.center_price_input.setDisabled(False)
+
+        if not self.view.strategy_widget.reset_on_partial_fill_input.isChecked():
+            self.view.strategy_widget.partial_fill_threshold_input.setDisabled(True)
+
+        if not self.view.strategy_widget.reset_on_price_change_input.isChecked():
+            self.view.strategy_widget.price_change_threshold_input.setDisabled(True)
+
+        if not self.view.strategy_widget.custom_expiration_input.isChecked():
+            self.view.strategy_widget.expiration_time_input.setDisabled(True)
 
     def onchange_relative_order_size_input(self, checked):
         if checked:
@@ -109,8 +127,31 @@ class RelativeOrdersController(StrategyController):
     def onchange_center_price_dynamic_input(self, checked):
         if checked:
             self.view.strategy_widget.center_price_input.setDisabled(True)
+            self.view.strategy_widget.reset_on_price_change_input.setDisabled(False)
+            if self.view.strategy_widget.reset_on_price_change_input.isChecked():
+                self.view.strategy_widget.price_change_threshold_input.setDisabled(False)
         else:
             self.view.strategy_widget.center_price_input.setDisabled(False)
+            self.view.strategy_widget.reset_on_price_change_input.setDisabled(True)
+            self.view.strategy_widget.price_change_threshold_input.setDisabled(True)
+
+    def onchange_reset_on_partial_fill_input(self, checked):
+        if checked:
+            self.view.strategy_widget.partial_fill_threshold_input.setDisabled(False)
+        else:
+            self.view.strategy_widget.partial_fill_threshold_input.setDisabled(True)
+
+    def onchange_reset_on_price_change_input(self, checked):
+        if checked:
+            self.view.strategy_widget.price_change_threshold_input.setDisabled(False)
+        else:
+            self.view.strategy_widget.price_change_threshold_input.setDisabled(True)
+
+    def onchange_custom_expiration_input(self, checked):
+        if checked:
+            self.view.strategy_widget.expiration_time_input.setDisabled(False)
+        else:
+            self.view.strategy_widget.expiration_time_input.setDisabled(True)
 
     def order_size_input_to_relative(self):
         self.view.strategy_widget.amount_input.setSuffix('%')

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -114,7 +114,7 @@ class Strategy(BaseStrategy):
         """
         if (self.is_reset_on_price_change and not
             self.counter % 8):
-            self.log.debug('checking orders by tick threshold')
+            self.log.debug('Checking orders by tick threshold')
             self.check_orders('tick')
         self.counter += 1
 

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -167,28 +167,33 @@ class Strategy(BaseStrategy):
         self.clear_orders()
 
         order_ids = []
+        expected_num_orders = 0
 
         amount_base = self.amount_base
         amount_quote = self.amount_quote
 
         # Buy Side
-        buy_order = self.market_buy(amount_base, self.buy_price, True)
-        if buy_order:
-            self.save_order(buy_order)
-            order_ids.append(buy_order['id'])
+        if amount_base:
+            buy_order = self.market_buy(amount_base, self.buy_price, True)
+            if buy_order:
+                self.save_order(buy_order)
+                order_ids.append(buy_order['id'])
+            expected_num_orders += 1
 
         # Sell Side
-        sell_order = self.market_sell(amount_quote, self.sell_price, True)
-        if sell_order:
-            self.save_order(sell_order)
-            order_ids.append(sell_order['id'])
+        if amount_quote:
+            sell_order = self.market_sell(amount_quote, self.sell_price, True)
+            if sell_order:
+                self.save_order(sell_order)
+                order_ids.append(sell_order['id'])
+            expected_num_orders += 1
 
         self['order_ids'] = order_ids
 
         self.log.info("Done placing orders")
 
         # Some orders weren't successfully created, redo them
-        if len(order_ids) < 2 and not self.disabled:
+        if len(order_ids) < expected_num_orders and not self.disabled:
             self.update_orders()
 
     def check_orders(self, event, *args, **kwargs):

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -97,7 +97,7 @@ class Strategy(BaseStrategy):
 
         # Check for conflicting settings
         if self.is_reset_on_price_change and not self.is_center_price_dynamic:
-            self.log.error('reset_on_price_change requires Dynamic Center Price')
+            self.log.error('"Reset orders on center price change" requires "Dynamic Center Price"')
             self.disabled = True
         self.update_orders()
 

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -100,7 +100,9 @@ class Strategy(BaseStrategy):
             self.log.error('"Reset orders on center price change" requires "Dynamic Center Price"')
             self.disabled = True
             return
-        self.update_orders()
+
+        # Old orders from previous run may still be on market, so let's check them
+        self.check_orders('init')
 
     def error(self, *args, **kwargs):
         self.cancel_all()

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -158,7 +158,7 @@ class Strategy(BaseStrategy):
         self.sell_price = self.center_price * math.sqrt(1 + self.spread)
 
     def update_orders(self):
-        #self.log.debug('Change detected, updating orders')
+        self.log.debug('Starting to update orders')
 
         # Recalculate buy and sell order prices
         self.calculate_order_prices()

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -89,6 +89,7 @@ class Strategy(BaseStrategy):
 
         self.buy_price = None
         self.sell_price = None
+        self.initializing = True
 
         self.initial_balance = self['initial_balance'] or 0
         self.worker_name = kwargs.get('name')
@@ -257,9 +258,10 @@ class Strategy(BaseStrategy):
 
         if need_update:
             self.update_orders()
-        else:
-            pass
-            #self.log.debug("Orders correct on market")
+        elif self.initializing:
+            self.log.info("Orders correct on market")
+
+        self.initializing = False
 
         if self.view:
             self.update_gui_profit()

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -1,8 +1,11 @@
 import math
+from datetime import datetime
+from datetime import timedelta
 
 from dexbot.basestrategy import BaseStrategy, ConfigElement
 from dexbot.qt_queue.idle_queue import idle_add
 
+from bitshares.price import FilledOrder
 
 class Strategy(BaseStrategy):
     """ Relative Orders strategy
@@ -26,14 +29,33 @@ class Strategy(BaseStrategy):
                           'Automatically adjust orders up or down based on the imbalance of your assets', None),
             ConfigElement('manual_offset', 'float', 0, 'Manual center price offset',
                           "Manually adjust orders up or down. "
-                          "Works independently of other offsets and doesn't override them", (-50, 100, 2, '%'))
+                          "Works independently of other offsets and doesn't override them", (-50, 100, 2, '%')),
+            ConfigElement('reset_on_partial_fill', 'bool', True, 'Reset orders on partial fill',
+                          'Reset orders when buy or sell order is partially filled', None),
+            ConfigElement('partial_fill_threshold', 'float', 30, 'Fill threshold',
+                          'Fill threshold to reset orders', (0, 100, 2, '%')),
+            ConfigElement('reset_on_market_trade', 'bool', False, 'Reset orders on market trade',
+                          'Reset orders when detected a market trade', None),
+            ConfigElement('reset_on_price_change', 'bool', False, 'Reset orders on center price change',
+                          'Reset orders when center price is changed more than threshold', None),
+            ConfigElement('price_change_threshold', 'float', 2, 'Price change threshold',
+                          'Define center price threshold to react on', (0, 100, 2, '%')),
+            ConfigElement('custom_expiration', 'bool', False, 'Custom expiration',
+                          'Override order expiration time to trigger a reset', None),
+            ConfigElement('expiration_time', 'int', 157680000, 'Order expiration time',
+                          'Define custom order expiration time to force orders reset more often, seconds',
+                          (30, 157680000, ''))
         ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.log.info("Initializing Relative Orders")
 
+        # Tick counter
+        self.counter = 0
+
         # Define Callbacks
+        self.ontick += self.tick
         self.onMarketUpdate += self.check_orders
         self.onAccount += self.check_orders
 
@@ -52,6 +74,18 @@ class Strategy(BaseStrategy):
         self.manual_offset = self.worker.get('manual_offset', 0) / 100
         self.order_size = float(self.worker.get('amount', 1))
         self.spread = self.worker.get('spread') / 100
+        self.is_reset_on_partial_fill = self.worker.get('reset_on_partial_fill', True)
+        self.partial_fill_threshold = self.worker.get('partial_fill_threshold', 30) / 100
+        self.is_reset_on_market_trade = self.worker.get('reset_on_market_trade', False)
+        self.is_reset_on_price_change = self.worker.get('reset_on_price_change', False)
+        self.price_change_threshold = self.worker.get('price_change_threshold', 2) / 100
+        self.is_custom_expiration = self.worker.get('custom_expiration', False)
+
+        if self.is_custom_expiration:
+            self.expiration = self.worker.get('expiration_time', self.expiration)
+
+        self.last_check = datetime.now()
+        self.min_check_interval = 8
 
         self.buy_price = None
         self.sell_price = None
@@ -59,11 +93,26 @@ class Strategy(BaseStrategy):
         self.initial_balance = self['initial_balance'] or 0
         self.worker_name = kwargs.get('name')
         self.view = kwargs.get('view')
-        self.check_orders()
+
+        # Check for conflicting settings
+        if self.is_reset_on_price_change and not self.is_center_price_dynamic:
+            self.log.error('reset_on_price_change requires Dynamic Center Price')
+            self.disabled = True
+        self.update_orders()
 
     def error(self, *args, **kwargs):
         self.cancel_all()
         self.disabled = True
+
+    def tick(self, d):
+        """ Ticks come in on every block. We need to periodically check orders because cancelled orders
+            do not triggers a market_update event
+        """
+        if (self.is_reset_on_price_change and not
+            self.counter % 8):
+            self.log.debug('checking orders by tick threshold')
+            self.check_orders('tick')
+        self.counter += 1
 
     @property
     def amount_quote(self):
@@ -108,7 +157,7 @@ class Strategy(BaseStrategy):
         self.sell_price = self.center_price * math.sqrt(1 + self.spread)
 
     def update_orders(self):
-        self.log.info('Change detected, updating orders')
+        #self.log.debug('Change detected, updating orders')
 
         # Recalculate buy and sell order prices
         self.calculate_order_prices()
@@ -142,32 +191,76 @@ class Strategy(BaseStrategy):
         if len(order_ids) < 2 and not self.disabled:
             self.update_orders()
 
-    def check_orders(self, *args, **kwargs):
+    def check_orders(self, event, *args, **kwargs):
         """ Tests if the orders need updating
         """
+        delta = datetime.now() - self.last_check
+
+        # Only allow to check orders whether minimal time passed
+        if delta < timedelta(seconds=self.min_check_interval):
+            self.log.debug('Ignoring market_update event as min_check_interval is not passed')
+            return
+
         orders = self.fetch_orders()
 
+        # Detect complete fill, order expiration, manual cancel, or just init
+        need_update = False
         if not orders:
-            self.update_orders()
+            need_update = True
         else:
-            orders_changed = False
-
             # Loop trough the orders and look for changes
             for order_id, order in orders.items():
                 current_order = self.get_order(order_id)
 
                 if not current_order:
-                    orders_changed = True
-                    self.write_order_log(self.worker_name, order)
+                    need_update = True
+                    self.log.debug('Could not found order on the market, it was filled, expired or cancelled')
+                    # FIXME: writing a log entry is disabled because we cannot distinguish an expired order
+                    #        from filled
+                    #self.write_order_log(self.worker_name, order)
+                elif self.is_reset_on_partial_fill:
+                    # Detect partially filled orders;
+                    # on fresh order 'for_sale' is always equal to ['base']['amount']
+                    if current_order['for_sale']['amount'] != current_order['base']['amount']:
+                        diff_abs = current_order['base']['amount'] - current_order['for_sale']['amount']
+                        diff_rel = diff_abs / current_order['base']['amount']
+                        if diff_rel >= self.partial_fill_threshold:
+                            need_update = True
+                            self.log.info('Partially filled order detected, filled {:.2%}'.format(diff_rel))
+                            # FIXME: need to write trade operation; possible race condition may occur: while
+                            #        we're updating order it may be filled futher so trade log entry will not
+                            #        be correct
 
-            if orders_changed:
-                self.update_orders()
-            else:
-                self.log.info("Orders correct on market")
+        if (self.is_reset_on_market_trade and
+            isinstance(event, FilledOrder)):
+            self.log.debug('Market trade detected, updating orders')
+            need_update = True
+
+        if self.is_reset_on_price_change:
+            center_price = self.calculate_center_price(
+                None,
+                self.is_asset_offset,
+                self.spread,
+                self['order_ids'],
+                self.manual_offset
+            )
+            diff = (self.center_price - center_price) / self.center_price
+            diff = abs(diff)
+            if diff >= self.price_change_threshold:
+                self.log.debug('Center price changed, updating orders. Diff: {:.2%}'.format(diff))
+                need_update = True
+
+        if need_update:
+            self.update_orders()
+        else:
+            pass
+            #self.log.debug("Orders correct on market")
 
         if self.view:
             self.update_gui_profit()
             self.update_gui_slider()
+
+        self.last_check = datetime.now()
 
     # GUI updaters
     def update_gui_profit(self):

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -101,8 +101,13 @@ class Strategy(BaseStrategy):
             self.disabled = True
             return
 
-        # Old orders from previous run may still be on market, so let's check them
-        self.check_orders('init')
+        # Check old orders from previous run (from force-interruption) only whether we are not using "Reset orders on
+        # center price change" option
+        if self.is_reset_on_price_change:
+            self.log.info('"Reset orders on center price change" is active, placing fresh orders')
+            self.update_orders()
+        else:
+            self.check_orders('init')
 
     def error(self, *args, **kwargs):
         self.cancel_all()

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -207,7 +207,7 @@ class Strategy(BaseStrategy):
         delta = datetime.now() - self.last_check
 
         # Only allow to check orders whether minimal time passed
-        if delta < timedelta(seconds=self.min_check_interval):
+        if delta < timedelta(seconds=self.min_check_interval) and not self.initializing:
             self.log.debug('Ignoring market_update event as min_check_interval is not passed')
             return
 

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -224,9 +224,10 @@ class Strategy(BaseStrategy):
                 if not current_order:
                     need_update = True
                     self.log.debug('Could not found order on the market, it was filled, expired or cancelled')
-                    # FIXME: writing a log entry is disabled because we cannot distinguish an expired order
-                    #        from filled
-                    #self.write_order_log(self.worker_name, order)
+                    # Write a trade log entry only when we are not using custom expiration because we cannot
+                    # distinguish an expired order from filled
+                    if not self.is_custom_expiration:
+                        self.write_order_log(self.worker_name, order)
                 elif self.is_reset_on_partial_fill:
                     # Detect partially filled orders;
                     # on fresh order 'for_sale' is always equal to ['base']['amount']

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -99,6 +99,7 @@ class Strategy(BaseStrategy):
         if self.is_reset_on_price_change and not self.is_center_price_dynamic:
             self.log.error('"Reset orders on center price change" requires "Dynamic Center Price"')
             self.disabled = True
+            return
         self.update_orders()
 
     def error(self, *args, **kwargs):

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -32,7 +32,7 @@ class Strategy(BaseStrategy):
             ConfigElement('reset_on_partial_fill', 'bool', True, 'Reset orders on partial fill',
                           'Reset orders when buy or sell order is partially filled', None),
             ConfigElement('partial_fill_threshold', 'float', 30, 'Fill threshold',
-                          'Fill threshold to reset orders', (0, 100, 2, '%')),
+                          'Order fill threshold to reset orders', (0, 100, 2, '%')),
             ConfigElement('reset_on_market_trade', 'bool', False, 'Reset orders on market trade',
                           'Reset orders when detected a market trade', None),
             ConfigElement('reset_on_price_change', 'bool', False, 'Reset orders on center price change',

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -1,6 +1,5 @@
 import math
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from dexbot.basestrategy import BaseStrategy, ConfigElement
 from dexbot.qt_queue.idle_queue import idle_add


### PR DESCRIPTION
- Always reset orders whether it was a filled, expired or manually
cancelled order detected
- Reset on partial fill (with % threshold, optional)
- Allow to define custom order expiration time
- Reset orders on market trade (optional)
- Reset orders on center price change threshold (optional)

- Also disable log message about correct orders to remove log noise
- Writing of a trade log entry is disabled because we cannot properly
distinguish an expired order from a filled one

Closes: #226, #270