### PR TITLE
use pkg_resources to allow auto-discovery of third-party strategies

### DIFF
--- a/dexbot/cli_conf.py
+++ b/dexbot/cli_conf.py
@@ -23,8 +23,8 @@ import subprocess
 
 from dexbot.whiptail import get_whiptail
 from dexbot.basestrategy import BaseStrategy
+import dexbot.helper
 
-# FIXME: auto-discovery of strategies would be cool but can't figure out a way
 STRATEGIES = [
     {'tag': 'relative',
      'class': 'dexbot.strategies.relative_orders',
@@ -32,6 +32,17 @@ STRATEGIES = [
     {'tag': 'stagger',
      'class': 'dexbot.strategies.staggered_orders',
      'name': 'Staggered Orders'}]
+
+tags_so_far = {'stagger', 'relative'}
+for desc, module in dexbot.helper.find_external_strategies():
+    tag = desc.split()[0].lower()
+    # make sure tag is unique
+    i = 1
+    while tag in tags_so_far:
+        tag = tag+str(i)
+        i += 1
+    tags_so_far.add(tag)
+    STRATEGIES.append({'tag': tag, 'class': module, 'name': desc})
 
 SYSTEMD_SERVICE_NAME = os.path.expanduser(
     "~/.local/share/systemd/user/dexbot.service")

--- a/dexbot/controllers/worker_controller.py
+++ b/dexbot/controllers/worker_controller.py
@@ -3,6 +3,7 @@ import re
 
 from dexbot.views.errors import gui_error
 from dexbot.config import Config
+from dexbot.helper import find_external_strategies
 from dexbot.views.notice import NoticeDialog
 from dexbot.views.confirmation import ConfirmationDialog
 from dexbot.views.strategy_form import StrategyFormWidget
@@ -33,6 +34,9 @@ class WorkerController:
             'name': 'Staggered Orders',
             'form_module': 'dexbot.views.ui.forms.staggered_orders_widget_ui'
         }
+        for desc, module in find_external_strategies():
+            strategies[module] = {'name': desc, 'form_module': module}
+            # if there is no UI form in the module then GUI will gracefully revert to auto-ui
         return strategies
 
     @classmethod

--- a/dexbot/helper.py
+++ b/dexbot/helper.py
@@ -3,6 +3,7 @@ import math
 import shutil
 import errno
 import logging
+import importlib
 from appdirs import user_data_dir
 
 from dexbot import APP_NAME, AUTHOR
@@ -57,3 +58,26 @@ def initialize_orders_log():
 
     if not file:
         logger.info("worker_name;ID;operation_type;base_asset;base_amount;quote_asset;quote_amount;timestamp")
+
+
+try:
+    # unfortunately setuptools is only "kinda-sorta" a standard module
+    # it's available on pretty much any modern Python system, but some embedded Pythons may not have it
+    # so we make it a soft-dependency
+    import pkg_resources
+
+    def find_external_strategies():
+        """Use setuptools introspection to find third-party strategies the user may have installed.
+        Packages that provide a strategy should export a setuptools "entry point" (see setuptools docs)
+        with group "dexbot.strategy", "name" is the display name of the strategy. 
+        Only set the module not any attribute (because it would always be a class called "Strategy")
+        If you want a handwritten graphical UI, define "Ui_Form" and "StrategyController" in the same module
+
+        yields a 2-tuple: description, module name"""
+        for entry_point in pkg_resources.iter_entry_points("dexbot.strategy"):
+            yield (entry_point.name, entry_point.module_name)
+
+except ImportError:
+    # our system doesn't have setuptools, so no way to find external strategies
+    def find_external_strategies():
+        return []

--- a/dexbot/views/strategy_form.py
+++ b/dexbot/views/strategy_form.py
@@ -35,17 +35,24 @@ class StrategyFormWidget(QtWidgets.QWidget):
         class_name = ''.join([class_name, 'Controller'])
 
         try:
-            # Try to get the controller
+            # Try to get the controller from the internal set
             strategy_controller = getattr(
                 dexbot.controllers.strategy_controller,
                 class_name
             )
         except AttributeError:
-            # The controller doesn't exist, use the default controller
-            strategy_controller = getattr(
-                dexbot.controllers.strategy_controller,
-                'StrategyController'
-            )
+            try:
+                # look in the strategy module itself (external strategies may do this)
+                strategy_controller = getattr(
+                    importlib.import_module(strategy_module),
+                    'StrategyController'
+                )
+            except AttributeError:
+                # The controller doesn't exist, use the default controller
+                strategy_controller = getattr(
+                    dexbot.controllers.strategy_controller,
+                    'StrategyController'
+                )
 
         self.strategy_controller = strategy_controller(self, configure, controller, worker_config)
 


### PR DESCRIPTION
this allows strategies to be published in external packages and made available via `pip` 
these can then be found and presented to the user during configuration