### PR TITLE
websocket-client version 0.48.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ install_requires = [
     'ruamel.yaml>=0.15.37',
     'sdnotify',
     'appdirs>=1.4.3',
-    'pycryptodomex==3.6.4'
+    'pycryptodomex==3.6.4',
+    'websocket-client==0.48.0'
 ]
 
 


### PR DESCRIPTION
Adds websocket-client version 0.48.0 to the requirements.