### PR TITLE
Added runservice to run dexbot-cli as a service: dexbot-cli runservice

### DIFF
--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -95,7 +95,7 @@ def run(ctx):
             # signal.signal(signal.SIGUSR1, lambda x, y: worker.do_next_tick(worker.reread_config))
         except ValueError:
             log.debug("Cannot set all signals -- not available on this platform")
-        if ctx.obj['systemd'] or ctx.obj['d']:
+        if ctx.obj['systemd']:
             try:
                 import sdnotify  # A soft dependency on sdnotify -- don't crash on non-systemd systems
                 n = sdnotify.SystemdNotifier()

--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -6,7 +6,7 @@ import signal
 import sys
 
 from dexbot.config import Config, DEFAULT_CONFIG_FILE
-from dexbot.cli_conf import *
+from dexbot.cli_conf import SYSTEMD_SERVICE_NAME, get_whiptail, setup_systemd
 from dexbot.helper import initialize_orders_log, initialize_data_folders
 from dexbot.ui import (
     verbose,


### PR DESCRIPTION
dexbot-cli --systemd run was not running the cli as a service so i added a new command runservice.
It use the cli_conf.py to generate the service file if not present.

=> dexbot-cli runservice