### PR TITLE
External price feed for Relative Orders GUI

### DIFF
--- a/dexbot/controllers/strategy_controller.py
+++ b/dexbot/controllers/strategy_controller.py
@@ -169,6 +169,10 @@ class RelativeOrdersController(StrategyController):
             self.view.strategy_widget.center_price_input.setDisabled(True)
             self.view.strategy_widget.center_price_depth_input.setDisabled(False)
             self.view.strategy_widget.reset_on_price_change_input.setDisabled(False)
+            self.view.strategy_widget.external_feed_input.setEnabled(True)
+
+            if self.view.strategy_widget.external_feed_input.isChecked():
+                self.view.strategy_widget.external_price_source_input.setEnabled(True)
 
             if self.view.strategy_widget.reset_on_price_change_input.isChecked():
                 self.view.strategy_widget.price_change_threshold_input.setDisabled(False)
@@ -177,6 +181,9 @@ class RelativeOrdersController(StrategyController):
             self.view.strategy_widget.center_price_depth_input.setDisabled(True)
             self.view.strategy_widget.reset_on_price_change_input.setDisabled(True)
             self.view.strategy_widget.price_change_threshold_input.setDisabled(True)
+            self.view.strategy_widget.external_feed_input.setChecked(False)
+            self.view.strategy_widget.external_feed_input.setDisabled(True)
+            self.view.strategy_widget.external_price_source_input.setDisabled(True)
 
     def onchange_reset_on_partial_fill_input(self, checked):
         if checked:

--- a/dexbot/controllers/strategy_controller.py
+++ b/dexbot/controllers/strategy_controller.py
@@ -106,6 +106,7 @@ class RelativeOrdersController(StrategyController):
         widget = self.view.strategy_widget
 
         # Event connecting
+        widget.external_feed_input.clicked.connect(self.onchange_external_feed_input)
         widget.relative_order_size_input.clicked.connect(self.onchange_relative_order_size_input)
         widget.dynamic_spread_input.clicked.connect(self.onchange_dynamic_spread_input)
         widget.center_price_dynamic_input.clicked.connect(self.onchange_center_price_dynamic_input)
@@ -115,6 +116,7 @@ class RelativeOrdersController(StrategyController):
         widget.custom_expiration_input.clicked.connect(self.onchange_custom_expiration_input)
 
         # Trigger the onchange events once
+        self.onchange_external_feed_input(widget.external_feed_input.isChecked())
         self.onchange_relative_order_size_input(widget.relative_order_size_input.isChecked())
         self.onchange_center_price_dynamic_input(widget.center_price_dynamic_input.isChecked())
         self.onchange_dynamic_spread_input(widget.dynamic_spread_input.isChecked())
@@ -129,6 +131,15 @@ class RelativeOrdersController(StrategyController):
         values = super().values
         values['manual_offset'] = values['manual_offset'] / 10
         return values
+
+    def onchange_external_feed_input(self, checked):
+        if checked:
+            self.view.strategy_widget.external_price_source_input.setDisabled(False)
+
+            self.view.strategy_widget.reset_on_price_change_input.setChecked(False)
+            self.view.strategy_widget.price_change_threshold_input.setDisabled(True)
+        else:
+            self.view.strategy_widget.external_price_source_input.setDisabled(True)
 
     def onchange_manual_offset_input(self):
         value = self.view.strategy_widget.manual_offset_input.value() / 10
@@ -176,6 +187,10 @@ class RelativeOrdersController(StrategyController):
     def onchange_reset_on_price_change_input(self, checked):
         if checked and self.view.strategy_widget.center_price_dynamic_input.isChecked():
             self.view.strategy_widget.price_change_threshold_input.setDisabled(False)
+
+            # Disable external price feed
+            self.view.strategy_widget.external_feed_input.setChecked(False)
+            self.view.strategy_widget.external_price_source_input.setDisabled(True)
         else:
             self.view.strategy_widget.price_change_threshold_input.setDisabled(True)
 

--- a/dexbot/controllers/worker_controller.py
+++ b/dexbot/controllers/worker_controller.py
@@ -85,8 +85,8 @@ class WorkerController:
         return worker_data['mode']
 
     @staticmethod
-    def get_allow_instant_fill(worder_data):
-        return worder_data['allow_instant_fill']
+    def get_allow_instant_fill(worker_data):
+        return worker_data['allow_instant_fill']
 
     @staticmethod
     def get_assets(worker_data):

--- a/dexbot/strategies/base.py
+++ b/dexbot/strategies/base.py
@@ -606,7 +606,11 @@ class StrategyBase(BaseStrategy, Storage, StateMachine, Events):
             return None
 
     def get_external_market_center_price(self, external_price_source):
-        center_price = None
+        """ Get center price from an external market for current market pair
+
+            :param external_price_source: External market name
+            :return: Center price as float
+        """
         self.log.debug('inside get_external_mcp, exchange: {} '.format(external_price_source))
         market = self.market.get_string('/')
         self.log.debug('market: {}  '.format(market))

--- a/dexbot/strategies/external_feeds/ccxt_feed.py
+++ b/dexbot/strategies/external_feeds/ccxt_feed.py
@@ -37,6 +37,9 @@ async def fetch_ticker(exchange, symbol):
 def get_ccxt_price(symbol, exchange_name):
     """ Get all tickers from multiple exchanges using async """
     center_price = None
+
+    async_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(async_loop)
     exchange = getattr(accxt, exchange_name)({'verbose': False})
     ticker = asyncio.get_event_loop().run_until_complete(fetch_ticker(exchange, symbol))
     if ticker:

--- a/dexbot/strategies/external_feeds/gecko_feed.py
+++ b/dexbot/strategies/external_feeds/gecko_feed.py
@@ -19,7 +19,11 @@ async def get_json(url):
 
 def _get_market_price(base, quote):
     try:
+        async_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(async_loop)
+
         coin_list = asyncio.get_event_loop().run_until_complete(get_json(GECKO_COINS_URL + 'list'))
+
         quote_name = check_gecko_symbol_exists(coin_list, quote.lower())
         lookup_pair = "?vs_currency=" + base.lower() + "&ids=" + quote_name
         market_url = GECKO_COINS_URL + 'markets' + lookup_pair

--- a/dexbot/strategies/external_feeds/price_feed.py
+++ b/dexbot/strategies/external_feeds/price_feed.py
@@ -88,13 +88,13 @@ class PriceFeed:
         price = None
         if self._exchange not in self._alt_exchanges:
             price = get_ccxt_price(symbol, self._exchange)
-            debug("use ccxt exchange ", self._exchange, ' symbol ', symbol, ' price:', price)
+            debug('Use ccxt exchange {} symbol {} price: {}'.format(self.exchange, symbol, price))
         elif self._exchange == 'gecko':
             price = get_gecko_price(symbol_=symbol)
-            debug("gecko exchange - ", self._exchange, ' symbol ', symbol, ' price:', price)
+            debug('Use ccxt exchange {} symbol {} price: {}'.format(self.exchange, symbol, price))
         elif self._exchange == 'waves':
             price = get_waves_price(symbol_=symbol)
-            debug("use waves -", self._exchange, ' symbol ', symbol, ' price:', price)
+            debug('Use waves exchange {} symbol {} price: {}'.format(self.exchange, symbol, price))
         return price
 
     def get_center_price(self, type):

--- a/dexbot/strategies/external_feeds/waves_feed.py
+++ b/dexbot/strategies/external_feeds/waves_feed.py
@@ -16,6 +16,8 @@ def get_last_price(base, quote):
     current_price = None
     try:
         market_bq = MARKET_URL + quote + '/' + base  # external exchange format
+        async_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(async_loop)
         ticker = asyncio.get_event_loop().run_until_complete(get_json(WAVES_URL + market_bq))
         current_price = ticker['24h_close']
     except Exception as exeption:
@@ -24,6 +26,8 @@ def get_last_price(base, quote):
 
 
 def get_waves_symbols():
+    async_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(async_loop)
     symbol_list = asyncio.get_event_loop().run_until_complete(get_json(WAVES_URL + SYMBOLS_URL))
     return symbol_list
 

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -1,7 +1,7 @@
 import math
 from datetime import datetime, timedelta
 
-from dexbot.strategies.base import StrategyBase, ConfigElement, DetailElement
+from dexbot.strategies.base import StrategyBase, ConfigElement, DetailElement, EXCHANGES
 from dexbot.qt_queue.idle_queue import idle_add
 
 
@@ -12,6 +12,10 @@ class Strategy(StrategyBase):
     @classmethod
     def configure(cls, return_base_config=True):
         return StrategyBase.configure(return_base_config) + [
+            ConfigElement('external_price_source', 'choice', EXCHANGES[0], 'External price source',
+                          'The bot will try to get price information from this source', EXCHANGES),
+            ConfigElement('external_feed', 'bool', False, 'External price feed',
+                          'Use external reference price instead of center price acquired from the market', None),
             ConfigElement('amount', 'float', 1, 'Amount',
                           'Fixed order size, expressed in quote asset, unless "relative order size" selected',
                           (0, None, 8, '')),
@@ -44,7 +48,8 @@ class Strategy(StrategyBase):
             ConfigElement('partial_fill_threshold', 'float', 30, 'Fill threshold',
                           'Order fill threshold to reset orders', (0, 100, 2, '%')),
             ConfigElement('reset_on_price_change', 'bool', False, 'Reset orders on center price change',
-                          'Reset orders when center price is changed more than threshold (set False for external feeds)', None),
+                          'Reset orders when center price is changed more than threshold '
+                          '(set False for external feeds)', None),
             ConfigElement('price_change_threshold', 'float', 2, 'Price change threshold',
                           'Define center price threshold to react on', (0, 100, 2, '%')),
             ConfigElement('custom_expiration', 'bool', False, 'Custom expiration',
@@ -80,19 +85,27 @@ class Strategy(StrategyBase):
 
         if not self.market_center_price:
             self.empty_market = True
-            
+
+        # Set external price source, defaults to False if not found
+        self.external_feed = self.worker.get('external_feed', False)
+        self.external_price_source = self.worker.get('external_price_source', None)
+
         # Worker parameters
         self.is_center_price_dynamic = self.worker['center_price_dynamic']
+
         if self.is_center_price_dynamic:
             self.center_price = None
             self.center_price_depth = self.worker.get('center_price_depth', 0)
         else:
-            external_source = self.external_price_source
-            if external_source != 'none':
-                self.center_price = self.get_external_market_center_price()
+            if self.external_feed:
+                # Try getting center price from external source
+                self.center_price = self.get_external_market_center_price(self.external_price_source)
+
                 if self.center_price is None:
-                    self.center_price = self.worker["center_price"]  # Set as manual
+                    # Use manual center price as fallback
+                    self.center_price = self.worker["center_price"]
             else:
+                # Use manually set center price
                 self.center_price = self.worker["center_price"]
             
         self.is_relative_order_size = self.worker.get('relative_order_size', False)

--- a/dexbot/views/ui/forms/relative_orders_widget.ui
+++ b/dexbot/views/ui/forms/relative_orders_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>449</width>
-    <height>675</height>
+    <height>687</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -2333,6 +2333,12 @@ QSlider::handle:horizontal {
        <widget class="QComboBox" name="external_price_source_input">
         <property name="enabled">
          <bool>true</bool>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>170</width>
+          <height>16777215</height>
+         </size>
         </property>
         <property name="currentIndex">
          <number>-1</number>

--- a/dexbot/views/ui/forms/relative_orders_widget.ui
+++ b/dexbot/views/ui/forms/relative_orders_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>449</width>
-    <height>597</height>
+    <height>675</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,7 +32,7 @@
       <string>Worker Parameters</string>
      </property>
      <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
+      <item row="2" column="0">
        <widget class="QWidget" name="order_size_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -127,7 +127,7 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="2" column="1">
        <widget class="QWidget" name="amount_input_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -207,7 +207,7 @@
         </layout>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="3" column="0">
        <widget class="QWidget" name="relative_order_size_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -287,14 +287,14 @@
         </layout>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="3" column="1">
        <widget class="QCheckBox" name="relative_order_size_input">
         <property name="text">
          <string>Relative order size</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="4" column="0">
        <widget class="QWidget" name="spread_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -389,7 +389,7 @@
         </layout>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="4" column="1">
        <widget class="QDoubleSpinBox" name="spread_input">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -420,7 +420,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="5" column="0">
        <widget class="QWidget" name="dynamic_spread_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -500,14 +500,14 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="5" column="1">
        <widget class="QCheckBox" name="dynamic_spread_input">
         <property name="text">
          <string>Dynamic spread</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="6" column="0">
        <widget class="QWidget" name="market_depth_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -605,7 +605,7 @@
         </layout>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="6" column="1">
        <widget class="QWidget" name="market_depth_amount_input_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -685,7 +685,7 @@
         </layout>
        </widget>
       </item>
-      <item row="5" column="0">
+      <item row="7" column="0">
        <widget class="QWidget" name="dynamic_spread_factor_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -783,7 +783,7 @@
         </layout>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="7" column="1">
        <widget class="QDoubleSpinBox" name="dynamic_spread_factor_input">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -817,7 +817,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="8" column="0">
        <widget class="QWidget" name="center_price_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -912,7 +912,7 @@
         </layout>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="8" column="1">
        <widget class="QWidget" name="center_price_input_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1010,7 +1010,7 @@
         </layout>
        </widget>
       </item>
-      <item row="7" column="0">
+      <item row="9" column="0">
        <widget class="QWidget" name="center_price_dynamic_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1090,7 +1090,7 @@
         </layout>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="9" column="1">
        <widget class="QCheckBox" name="center_price_dynamic_input">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1109,7 +1109,7 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
+      <item row="10" column="0">
        <widget class="QWidget" name="center_price_depth_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1207,7 +1207,7 @@
         </layout>
        </widget>
       </item>
-      <item row="8" column="1">
+      <item row="10" column="1">
        <widget class="QWidget" name="center_price_depth_input_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1287,7 +1287,7 @@
         </layout>
        </widget>
       </item>
-      <item row="9" column="0">
+      <item row="15" column="0">
        <widget class="QWidget" name="balance_offset_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1367,14 +1367,14 @@
         </layout>
        </widget>
       </item>
-      <item row="9" column="1">
+      <item row="15" column="1">
        <widget class="QCheckBox" name="center_price_offset_input">
         <property name="text">
          <string>Center price offset based on asset balances</string>
         </property>
        </widget>
       </item>
-      <item row="10" column="0">
+      <item row="16" column="0">
        <widget class="QWidget" name="manual_offset_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -1469,7 +1469,7 @@
         </layout>
        </widget>
       </item>
-      <item row="10" column="1">
+      <item row="16" column="1">
        <widget class="QWidget" name="manual_offset_input_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1592,7 +1592,7 @@ QSlider::handle:horizontal {
         </layout>
        </widget>
       </item>
-      <item row="11" column="0">
+      <item row="17" column="0">
        <widget class="QWidget" name="reset_on_partial_fill_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1672,14 +1672,14 @@ QSlider::handle:horizontal {
         </layout>
        </widget>
       </item>
-      <item row="11" column="1">
+      <item row="17" column="1">
        <widget class="QCheckBox" name="reset_on_partial_fill_input">
         <property name="text">
          <string>Reset orders on partial fill</string>
         </property>
        </widget>
       </item>
-      <item row="12" column="0">
+      <item row="18" column="0">
        <widget class="QWidget" name="partial_fill_threshold_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1774,7 +1774,7 @@ QSlider::handle:horizontal {
         </layout>
        </widget>
       </item>
-      <item row="12" column="1">
+      <item row="18" column="1">
        <widget class="QDoubleSpinBox" name="partial_fill_threshold_input">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -1805,7 +1805,7 @@ QSlider::handle:horizontal {
         </property>
        </widget>
       </item>
-      <item row="13" column="0">
+      <item row="19" column="0">
        <widget class="QWidget" name="reset_on_price_change_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1885,14 +1885,14 @@ QSlider::handle:horizontal {
         </layout>
        </widget>
       </item>
-      <item row="13" column="1">
+      <item row="19" column="1">
        <widget class="QCheckBox" name="reset_on_price_change_input">
         <property name="text">
          <string>Reset orders on center price change</string>
         </property>
        </widget>
       </item>
-      <item row="14" column="0">
+      <item row="20" column="0">
        <widget class="QWidget" name="price_change_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1987,7 +1987,7 @@ QSlider::handle:horizontal {
         </layout>
        </widget>
       </item>
-      <item row="14" column="1">
+      <item row="20" column="1">
        <widget class="QDoubleSpinBox" name="price_change_threshold_input">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -2018,7 +2018,7 @@ QSlider::handle:horizontal {
         </property>
        </widget>
       </item>
-      <item row="15" column="0">
+      <item row="21" column="0">
        <widget class="QWidget" name="balance_offset_wrap_4" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -2098,14 +2098,14 @@ QSlider::handle:horizontal {
         </layout>
        </widget>
       </item>
-      <item row="15" column="1">
+      <item row="21" column="1">
        <widget class="QCheckBox" name="custom_expiration_input">
         <property name="text">
          <string>Custom expiration</string>
         </property>
        </widget>
       </item>
-      <item row="16" column="0">
+      <item row="22" column="0">
        <widget class="QWidget" name="order_expiration_wrap" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -2200,7 +2200,7 @@ QSlider::handle:horizontal {
         </layout>
        </widget>
       </item>
-      <item row="16" column="1">
+      <item row="22" column="1">
        <widget class="QDoubleSpinBox" name="expiration_time_input">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -2231,6 +2231,198 @@ QSlider::handle:horizontal {
         </property>
         <property name="value">
          <double>5.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0">
+       <widget class="QWidget" name="external_feed_wrap" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>120</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_23">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="external_feed_label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>External feed</string>
+           </property>
+           <property name="buddy">
+            <cstring>amount_input</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="external_feed_tooltip">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="cursor">
+            <cursorShape>WhatsThisCursor</cursorShape>
+           </property>
+           <property name="toolTip">
+            <string>The bot will try to get price information from this source</string>
+           </property>
+           <property name="text">
+            <string>?</string>
+           </property>
+           <property name="margin">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="13" column="1">
+       <widget class="QComboBox" name="external_price_source_input">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="currentIndex">
+         <number>-1</number>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0">
+       <widget class="QWidget" name="extrenal_feed_wrap_2" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>120</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_25">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="external_feed_tooltip_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="cursor">
+            <cursorShape>WhatsThisCursor</cursorShape>
+           </property>
+           <property name="toolTip">
+            <string>Use external reference price instead of center price acquired from the market</string>
+           </property>
+           <property name="text">
+            <string>?</string>
+           </property>
+           <property name="margin">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <widget class="QCheckBox" name="external_feed_input">
+        <property name="text">
+         <string>Use external source for center price calculation</string>
         </property>
        </widget>
       </item>

--- a/tests/ccxt_test.py
+++ b/tests/ccxt_test.py
@@ -1,0 +1,58 @@
+from dexbot.strategies.external_feeds.price_feed import PriceFeed
+
+
+""" This is the unit test for testing price_feed module.
+    Run this test first to cover everything in external feeds
+
+    In DEXBot:
+        unit of measure = BASE
+        asset of interest = QUOTE
+"""
+
+
+def test_exchanges():
+    symbol = 'BTC/USD'
+    exchanges = ['gecko', 'bitfinex', 'kraken', 'gdax', 'binance', 'waves']
+
+    for exchange in exchanges:
+        price_feed = PriceFeed(exchange, symbol)
+        price_feed.filter_symbols()
+        center_price = price_feed.get_center_price(None)
+        print("Center price: {}".format(center_price))
+
+        if center_price is None:
+            # Try USDT
+            center_price = price_feed.get_center_price('USDT')
+            print("Try again, USD/USDT center price: {}".format(center_price))
+
+
+def test_consolidated_pair():
+    symbol = 'STEEM/BTS'  # STEEM/USD * USD/BTS = STEEM/BTS
+    price_feed = PriceFeed('gecko', symbol)
+    center_price = price_feed.get_consolidated_price()
+    print(center_price)
+
+
+def test_alternative_usd():
+    # Todo - Refactor price_feed to handle alt USD options.
+    alternative_usd = ['USDT', 'USDC', 'TUSD', 'GUSD']
+    exchanges = ['bittrex', 'poloniex', 'gemini', 'bitfinex', 'kraken', 'binance', 'okex']
+    symbol = 'BTC/USD'  # Replace with alt usd
+
+    for exchange in exchanges:
+        for alternative in alternative_usd:
+            price_feed = PriceFeed(exchange, symbol)
+            center_price = price_feed.get_center_price(None)
+
+            if center_price:
+                print('{} using alt: {} {}'.format(symbol, alternative, center_price))
+            else:
+                center_price = price_feed.get_center_price(alternative)
+                if center_price:
+                    print('{} using alt: {} {}'.format(symbol, alternative, center_price))
+
+
+if __name__ == '__main__':
+    test_exchanges()
+    test_consolidated_pair()
+    test_alternative_usd()


### PR DESCRIPTION
This feature uses new dependencies that require Python version 3.6.7 or newer to work properly as well as aiohttp==3.0.1, which is not included in this PR but there will be a separate one for that. 

Closes #399 