### PR TITLE
Log order id in case of Exception in get_order()

### DIFF
--- a/dexbot/strategies/base.py
+++ b/dexbot/strategies/base.py
@@ -1370,7 +1370,11 @@ class StrategyBase(Storage, StateMachine, Events):
             return None
         if 'id' in order_id:
             order_id = order_id['id']
-        order = Order(order_id)
+        try:
+            order = Order(order_id)
+        except Exception:
+            log.error('Got an exception getting order id {}'.format(order_id))
+            raise
         if return_none and order['deleted']:
             return None
         return order


### PR DESCRIPTION
Because issue #367 is not reproducible, add order_id logging for the
possible future occurencies of this bug.

Closes: #367