### PR TITLE
Bump uptick version to fix tabulate issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ cmd_class = {}
 console_scripts = ['dexbot-cli = dexbot.cli:main']
 install_requires = [
     'bitshares==0.2.1',
-    'uptick==0.2.0',
+    'uptick==0.2.1',
     'click',
     'sqlalchemy',
     'ruamel.yaml>=0.15.37',


### PR DESCRIPTION
  File "/home/vvk/devel/DEXBot/venv/lib/python3.6/site-packages/uptick-0.2.0-py3.6.egg/uptick/ui.py", line 7, in <module>
    from tabulate import tabulate
ModuleNotFoundError: No module named 'tabulate'

Closes: #431