### PR TITLE
#469 allow numeric in asset names

### DIFF
--- a/dexbot/strategies/base.py
+++ b/dexbot/strategies/base.py
@@ -155,7 +155,7 @@ class StrategyBase(Storage, StateMachine, Events):
                           ''),
             ConfigElement('market', 'string', 'USD:BTS', 'Market',
                           'BitShares market to operate on, in the format ASSET:OTHERASSET, for example \"USD:BTS\"',
-                          r'[A-Z\.]+[:\/][A-Z\.]+'),
+                          r'[A-Z0-9\.]+[:\/][A-Z0-9\.]+'),
             ConfigElement('fee_asset', 'string', 'BTS', 'Fee asset',
                           'Asset to be used to pay transaction fees',
                           r'[A-Z\.]+')


### PR DESCRIPTION
Allow numeric in asset names during configuration. Previously config threw an error when numbers were included.  #469