### PR TITLE
add uptick description to wallet password create for cli and .ui

### DIFF
--- a/dexbot/cli_conf.py
+++ b/dexbot/cli_conf.py
@@ -151,7 +151,7 @@ def setup_systemd(whiptail, config):
         path = os.path.expanduser(path)
         pathlib.Path(path).mkdir(parents=True, exist_ok=True)
         password = whiptail.prompt(
-            "The wallet password\n"
+            "The uptick wallet password\n"
             "NOTE: this will be saved on disc so the worker can run unattended. "
             "This means anyone with access to this computer's files can spend all your money",
             password=True)

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -99,19 +99,21 @@ def unlock(f):
                 else:
                     if systemd:
                         # No user available to interact with
-                        log.critical("Passphrase not available, exiting")
+                        log.critical("Uptick Passphrase not available, exiting")
                         sys.exit(78)  # 'configuration error' in sysexits.h
                     pwd = click.prompt(
-                        "Current Wallet Passphrase", hide_input=True)
+                        "Current Uptick Wallet Passphrase", hide_input=True)
                 ctx.bitshares.wallet.unlock(pwd)
             else:
                 if systemd:
                     # No user available to interact with
-                    log.critical("Wallet not installed, cannot run")
+                    log.critical("Uptick Wallet not installed, cannot run")
                     sys.exit(78)
-                click.echo("No wallet installed yet. Creating ...")
+                click.echo("No Uptick wallet installed yet. \n" + 
+                           "This is a password for encrypting " +
+                           "the file that contains your private keys.  Creating ...")
                 pwd = click.prompt(
-                    "Wallet Encryption Passphrase",
+                    "Uptick Wallet Encryption Passphrase",
                     hide_input=True,
                     confirmation_prompt=True)
                 ctx.bitshares.wallet.create(pwd)

--- a/dexbot/views/ui/create_wallet_window.ui
+++ b/dexbot/views/ui/create_wallet_window.ui
@@ -32,7 +32,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Before you can start using DEXBot, you need to create a wallet.</string>
+      <string>Before you can start using DEXBot, you need to create an uptick wallet.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -42,7 +42,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Wallet password is used to encrypt your BitShares account private keys.</string>
+      <string>The Uptick Wallet password is used to encrypt your BitShares account private keys.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -88,7 +88,7 @@
          <item row="0" column="0">
           <widget class="QLabel" name="password_label">
            <property name="text">
-            <string>Wallet password</string>
+            <string>Uptick Wallet password</string>
            </property>
            <property name="buddy">
             <cstring>password_input</cstring>

--- a/dexbot/views/ui/unlock_wallet_window.ui
+++ b/dexbot/views/ui/unlock_wallet_window.ui
@@ -32,7 +32,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Please enter your wallet password before continuing.</string>
+      <string>Please enter your Uptick wallet password before continuing.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -81,7 +81,7 @@
          <item row="0" column="0">
           <widget class="QLabel" name="password_label">
            <property name="text">
-            <string>Wallet password</string>
+            <string>Uptick Wallet password</string>
            </property>
            <property name="buddy">
             <cstring>password_input</cstring>


### PR DESCRIPTION
For end user clarification, indicate that the password to be created is for uptick wallet.