### PR TITLE
Auto-uncheck reset_on_price_change

### DIFF
--- a/dexbot/controllers/strategy_controller.py
+++ b/dexbot/controllers/strategy_controller.py
@@ -181,7 +181,11 @@ class RelativeOrdersController(StrategyController):
         else:
             self.view.strategy_widget.center_price_input.setDisabled(False)
             self.view.strategy_widget.center_price_depth_input.setDisabled(True)
+
+            # Disable and uncheck reset_on_price_change
             self.view.strategy_widget.reset_on_price_change_input.setDisabled(True)
+            self.view.strategy_widget.reset_on_price_change_input.setChecked(False)
+
             self.view.strategy_widget.price_change_threshold_input.setDisabled(True)
             self.view.strategy_widget.external_feed_input.setChecked(False)
             self.view.strategy_widget.external_feed_input.setDisabled(True)


### PR DESCRIPTION
Uncheck reset_on_price_change when center_price_dynamic set to False.
This prevents setting of bad options combination, thus avoiding further
error.