### PR TITLE
Prevent exiting from list lenght bound in whiptail menu

### DIFF
--- a/dexbot/whiptail.py
+++ b/dexbot/whiptail.py
@@ -144,8 +144,8 @@ class NoWhiptail:
             i += 1
         click.echo("\n")
         ret = click.prompt("Your choice:", type=int, default=default + 1)
-        ret = items[ret - 1]
-        return ret[0]
+        element_number = min(ret - 1, len(items) - 1)
+        return items[element_number][0]
 
     def radiolist(self, msg='', items=()):
         d = 0


### PR DESCRIPTION
If allowed input is in range 1-5 and user entered 6 or more, treat this
as 5.

Closes: #445