### PR TITLE
458 refactor cli configure

### DIFF
--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -93,7 +93,8 @@ def run(ctx):
             signal.signal(signal.SIGHUP, kill_workers)
             # TODO: reload config on SIGUSR1
             # signal.signal(signal.SIGUSR1, lambda x, y: worker.do_next_tick(worker.reread_config))
-        except ValueError:
+        except AttributeError:
+#        except ValueError:
             log.debug("Cannot set all signals -- not available on this platform")
         if ctx.obj['systemd']:
             try:
@@ -128,6 +129,7 @@ def runservice(ctx):
     click.echo("Starting dexbot daemon")
     os.system("systemctl --user start dexbot")
 
+    
 @main.command()
 @click.pass_context
 @configfile

--- a/dexbot/cli_conf.py
+++ b/dexbot/cli_conf.py
@@ -324,7 +324,7 @@ def configure_dexbot(config, ctx):
                  ('HELP', 'Where to get help'),
                  ('EXIT', 'Quit this application')])
 
-            my_workers = [(index, index) for index in workers])
+            my_workers = [(index, index) for index in workers]
             
             if action == 'EXIT':
                 ## cancel will also exit the application. but this is a clearer label
@@ -344,7 +344,7 @@ def configure_dexbot(config, ctx):
                 strategy = StrategyBase(worker_name, bitshares_instance=bitshares_instance, config=config)
                 strategy.clear_all_worker_data()
             elif action == 'NEW':
-                txt = whiptail.prompt("Your name for the new worker")
+                txt = whiptail.prompt("Your name for the new worker. Don't forget to add your bitshares key (main menu)")
                 config['workers'][txt] = configure_worker(whiptail, {})
             elif action == 'ADD':
                 account = whiptail.prompt("Your Account Name")

--- a/dexbot/cli_conf.py
+++ b/dexbot/cli_conf.py
@@ -93,7 +93,7 @@ def process_config_element(elem, whiptail, config):
                 txt = whiptail.prompt(
                     title, config.get(
                         elem.key, elem.default))
-        print("string ", elem.key, txt, sep=":") ## debug statement
+#        print("string ", elem.key, txt, sep=":") ## debug statement
         config[elem.key] = txt
 
     if elem.type == "bool":
@@ -282,7 +282,6 @@ def validate_private_key(bitshares, account, private_key):
 
     accounts = wallet.getAllAccounts(pubkey)
     account_names = [account['name'] for account in accounts]
-    print("Account names found in wallet:", account_names, sep=':')
     
     if account in account_names:
         return True

--- a/dexbot/cli_conf.py
+++ b/dexbot/cli_conf.py
@@ -326,6 +326,8 @@ def configure_dexbot(config, ctx):
                  ('EXIT', 'Quit this application')])
 
             if action == 'EXIT':
+                ## cancel will also exit the application. but this is a clearer label
+                ## todo: modify cancel to be "Quit" or "Exit"
                 break
             elif action =='LIST':
                 my_list = whiptail.menu("List of Your Workers", [(index, index) for index in workers])

--- a/dexbot/cli_conf.py
+++ b/dexbot/cli_conf.py
@@ -322,6 +322,7 @@ def configure_dexbot(config, ctx):
                  ('SHOW', 'Show bitshares accounts'),
                  ('NODES', 'Edit Node Selection'),
                  ('ADD_NODE', 'Add Your Node'),
+                 ('HELP', 'Where to get help'),
                  ('EXIT', 'Quit this application')])
 
             if action == 'EXIT':
@@ -330,6 +331,7 @@ def configure_dexbot(config, ctx):
                 break
             elif action =='LIST':
                 my_list = whiptail.menu("List of Your Workers", [(index, index) for index in workers])
+                
             elif action == 'EDIT':
                 worker_name = whiptail.menu("Select worker to edit", [(index, index) for index in workers])
                 config['workers'][worker_name] = configure_worker(whiptail, config['workers'][worker_name])
@@ -371,6 +373,8 @@ def configure_dexbot(config, ctx):
                 config['node'].remove(choice)
                 config['node'].insert(0, choice)
                 setup_systemd(whiptail, config)
-            
+            elif action == 'HELP':
+                whiptail.alert("Please see https://github.com/Codaone/DEXBot/wiki")
+                
     whiptail.clear()
     return config

--- a/dexbot/cli_conf.py
+++ b/dexbot/cli_conf.py
@@ -93,7 +93,6 @@ def process_config_element(elem, whiptail, config):
                 txt = whiptail.prompt(
                     title, config.get(
                         elem.key, elem.default))
-#        print("string ", elem.key, txt, sep=":") ## debug statement
         config[elem.key] = txt
 
     if elem.type == "bool":
@@ -325,12 +324,14 @@ def configure_dexbot(config, ctx):
                  ('HELP', 'Where to get help'),
                  ('EXIT', 'Quit this application')])
 
+            my_workers = [(index, index) for index in workers])
+            
             if action == 'EXIT':
                 ## cancel will also exit the application. but this is a clearer label
                 ## todo: modify cancel to be "Quit" or "Exit"
                 break
-            elif action =='LIST':
-                my_list = whiptail.menu("List of Your Workers", [(index, index) for index in workers])
+            elif action =='LIST':            
+                my_list = whiptail.menu("List of Your Workers", my_workers)
                 
             elif action == 'EDIT':
                 worker_name = whiptail.menu("Select worker to edit", [(index, index) for index in workers])
@@ -359,7 +360,10 @@ def configure_dexbot(config, ctx):
                 wallet = bitshares_instance.wallet
                 accounts = wallet.getAccounts()
                 account_list = [(i['name'], i['type']) for i in accounts]
+                if len(account_list) ==  0:
+                    account_list = [('none', 'none')]                    
                 action = whiptail.menu("Bitshares Account List (Name - Type)", account_list)
+
             elif action == 'ADD_NODE':
                 txt = whiptail.prompt("Your name for the new node: e.g. wss://dexnode.net/ws")
                 config['node'][0] = txt

--- a/dexbot/cli_helper.py
+++ b/dexbot/cli_helper.py
@@ -1,5 +1,3 @@
-import re
-
 from dexbot.whiptail import get_whiptail
 
 import bitshares
@@ -9,64 +7,6 @@ from bitshares.account import Account
 from bitshares.exceptions import KeyAlreadyInStoreException, AccountDoesNotExistsException
 from bitsharesbase.account import PrivateKey
 
-
-def select_choice(current, choices):
-    """ For the radiolist, get us a list with the current value selected """
-    return [(tag, text, (current == tag and "ON") or "OFF")
-            for tag, text in choices]
-
-
-def process_config_element(elem, whiptail, config):
-    """ Process an item of configuration metadata display a widget as appropriate
-        d: the Dialog object
-        config: the config dictionary for this worker
-    """
-    if elem.description:
-        title = '{} - {}'.format(elem.title, elem.description)
-    else:
-        title = elem.title
-
-    if elem.type == "string":
-        txt = whiptail.prompt(title, config.get(elem.key, elem.default))
-        if elem.extra:
-            while not re.match(elem.extra, txt):
-                whiptail.alert("The value is not valid")
-                txt = whiptail.prompt(
-                    title, config.get(
-                        elem.key, elem.default))
-        config[elem.key] = txt
-
-    if elem.type == "bool":
-        value = config.get(elem.key, elem.default)
-        value = 'yes' if value else 'no'
-        config[elem.key] = whiptail.confirm(title, value)
-
-    if elem.type in ("float", "int"):
-        while True:
-            if elem.type == 'int':
-                template = '{}'
-            else:
-                template = '{:.8f}'
-            txt = whiptail.prompt(title, template.format(config.get(elem.key, elem.default)))
-            try:
-                if elem.type == "int":
-                    val = int(txt)
-                else:
-                    val = float(txt)
-                if val < elem.extra[0]:
-                    whiptail.alert("The value is too low")
-                elif elem.extra[1] and val > elem.extra[1]:
-                    whiptail.alert("the value is too high")
-                else:
-                    break
-            except ValueError:
-                whiptail.alert("Not a valid value")
-        config[elem.key] = val
-
-    if elem.type == "choice":
-        config[elem.key] = whiptail.radiolist(title, select_choice(
-            config.get(elem.key, elem.default), elem.extra))
-
         
 class ConfigValidator:
     """ validation methods borrowed from gui WorkerController for Cli
@@ -75,23 +15,6 @@ class ConfigValidator:
     def __init__(self, whiptail, bitshares_instance):
         self.bitshares = bitshares_instance or shared_bitshares_instance()
         self.whiptail = whiptail
-
-    @classmethod
-    def validate_worker_name(cls, worker_name, old_worker_name=None):
-        if old_worker_name != worker_name:
-            worker_names = Config().workers_data.keys()
-            # Check that the name is unique
-            if worker_name in worker_names:
-                return False
-            return True
-        return True
-        
-    def validate_asset(self, asset):
-        try:
-            Asset(asset, bitshares_instance=self.bitshares)
-            return True
-        except bitshares.exceptions.AssetDoesNotExistsException:
-            return False
 
     def validate_account_name(self, account):
         if not account:
@@ -146,7 +69,7 @@ class ConfigValidator:
         if len(account_list) ==  0:
             account_list = [('none', 'none')]
         return account_list
-        
+
     def add_account(self):
         # this method modeled off of worker_controller in gui
         account = self.whiptail.prompt("Your Account Name")
@@ -166,3 +89,13 @@ class ConfigValidator:
         self.whiptail.alert("Private Key added successfully.")
         return account
 
+
+    def del_account(self):
+        # Todo: implement in the cli_conf
+        account = self.whiptail.prompt("Account Name")
+        public_key = self.whiptail.prompt("Public Key", password=True)
+        wallet = self.bitshares.wallet
+        try:
+            wallet.removePrivateKeyFromPublicKey(public_key)
+        except Exception:
+            pass

--- a/dexbot/cli_helper.py
+++ b/dexbot/cli_helper.py
@@ -1,0 +1,168 @@
+import re
+
+from dexbot.whiptail import get_whiptail
+
+import bitshares
+from bitshares.instance import shared_bitshares_instance
+from bitshares.asset import Asset
+from bitshares.account import Account
+from bitshares.exceptions import KeyAlreadyInStoreException, AccountDoesNotExistsException
+from bitsharesbase.account import PrivateKey
+
+
+def select_choice(current, choices):
+    """ For the radiolist, get us a list with the current value selected """
+    return [(tag, text, (current == tag and "ON") or "OFF")
+            for tag, text in choices]
+
+
+def process_config_element(elem, whiptail, config):
+    """ Process an item of configuration metadata display a widget as appropriate
+        d: the Dialog object
+        config: the config dictionary for this worker
+    """
+    if elem.description:
+        title = '{} - {}'.format(elem.title, elem.description)
+    else:
+        title = elem.title
+
+    if elem.type == "string":
+        txt = whiptail.prompt(title, config.get(elem.key, elem.default))
+        if elem.extra:
+            while not re.match(elem.extra, txt):
+                whiptail.alert("The value is not valid")
+                txt = whiptail.prompt(
+                    title, config.get(
+                        elem.key, elem.default))
+        config[elem.key] = txt
+
+    if elem.type == "bool":
+        value = config.get(elem.key, elem.default)
+        value = 'yes' if value else 'no'
+        config[elem.key] = whiptail.confirm(title, value)
+
+    if elem.type in ("float", "int"):
+        while True:
+            if elem.type == 'int':
+                template = '{}'
+            else:
+                template = '{:.8f}'
+            txt = whiptail.prompt(title, template.format(config.get(elem.key, elem.default)))
+            try:
+                if elem.type == "int":
+                    val = int(txt)
+                else:
+                    val = float(txt)
+                if val < elem.extra[0]:
+                    whiptail.alert("The value is too low")
+                elif elem.extra[1] and val > elem.extra[1]:
+                    whiptail.alert("the value is too high")
+                else:
+                    break
+            except ValueError:
+                whiptail.alert("Not a valid value")
+        config[elem.key] = val
+
+    if elem.type == "choice":
+        config[elem.key] = whiptail.radiolist(title, select_choice(
+            config.get(elem.key, elem.default), elem.extra))
+
+        
+class ConfigValidator:
+    """ validation methods borrowed from gui WorkerController for Cli
+    """
+
+    def __init__(self, whiptail, bitshares_instance):
+        self.bitshares = bitshares_instance or shared_bitshares_instance()
+        self.whiptail = whiptail
+
+    @classmethod
+    def validate_worker_name(cls, worker_name, old_worker_name=None):
+        if old_worker_name != worker_name:
+            worker_names = Config().workers_data.keys()
+            # Check that the name is unique
+            if worker_name in worker_names:
+                return False
+            return True
+        return True
+        
+    def validate_asset(self, asset):
+        try:
+            Asset(asset, bitshares_instance=self.bitshares)
+            return True
+        except bitshares.exceptions.AssetDoesNotExistsException:
+            return False
+
+    def validate_account_name(self, account):
+        if not account:
+            return False
+        try:
+            Account(account, bitshares_instance=self.bitshares)
+            return True
+        except bitshares.exceptions.AccountDoesNotExistsException:
+            return False
+
+    def validate_private_key(self, account, private_key):
+        wallet = self.bitshares.wallet
+        if not private_key:
+            # Check if the private key is already in the database
+            accounts = wallet.getAccounts()
+            if any(account == d['name'] for d in accounts):
+                return True
+            return False
+
+        try:
+            pubkey = format(PrivateKey(private_key).pubkey, self.bitshares.prefix)
+        except ValueError:
+            return False
+
+        accounts = wallet.getAllAccounts(pubkey)
+        account_names = [account['name'] for account in accounts]
+
+        if account in account_names:
+            return True
+        else:
+            return False
+
+    def validate_private_key_type(self, account, private_key):
+        account = Account(account)
+        pubkey = format(PrivateKey(private_key).pubkey, self.bitshares.prefix)
+        key_type = self.bitshares.wallet.getKeyType(account, pubkey)
+        if key_type != 'active' and key_type != 'owner':
+            return False
+        return True
+
+    def add_private_key(self, private_key):
+        wallet = self.bitshares.wallet
+        try:
+            wallet.addPrivateKey(private_key)
+        except KeyAlreadyInStoreException:
+            # Private key already added
+            pass
+        
+    def list_accounts(self):
+        accounts = self.bitshares.wallet.getAccounts()
+        account_list = [(i['name'], i['type']) for i in accounts]
+        if len(account_list) ==  0:
+            account_list = [('none', 'none')]
+        return account_list
+        
+    def add_account(self):
+        # this method modeled off of worker_controller in gui
+        account = self.whiptail.prompt("Your Account Name")
+        private_key = self.whiptail.prompt("Your Private Key", password=True)
+                    
+        if not self.validate_account_name(account):
+            self.whiptail.alert("Account name does not exist.")
+            return False
+        if not self.validate_private_key(account, private_key):
+            self.whiptail.alert("Private key is invalid")
+            return False
+        if private_key and not self.validate_private_key_type(account, private_key):
+            self.whiptail.alert("Please use active private key.")
+            return False
+        
+        self.add_private_key(private_key)
+        self.whiptail.alert("Private Key added successfully.")
+        return account
+

--- a/dexbot/strategies/base.py
+++ b/dexbot/strategies/base.py
@@ -153,6 +153,9 @@ class StrategyBase(Storage, StateMachine, Events):
             ConfigElement('account', 'string', '', 'Account',
                           'BitShares account name for the bot to operate with',
                           ''),
+            ConfigElement('wif', 'string', '', 'WIF Key',
+                          'BitShares WIF Key for the bot to operate with',
+                          ''),
             ConfigElement('market', 'string', 'USD:BTS', 'Market',
                           'BitShares market to operate on, in the format ASSET:OTHERASSET, for example \"USD:BTS\"',
                           r'[A-Z\.]+[:\/][A-Z\.]+'),
@@ -240,6 +243,8 @@ class StrategyBase(Storage, StateMachine, Events):
 
         # Get Bitshares account and market for this worker
         self._account = Account(self.worker["account"], full=True, bitshares_instance=self.bitshares)
+        self._wifkey = self.worker.get('wif')
+
         self._market = Market(config["workers"][name]["market"], bitshares_instance=self.bitshares)
 
         # Recheck flag - Tell the strategy to check for updated orders

--- a/dexbot/strategies/base.py
+++ b/dexbot/strategies/base.py
@@ -11,6 +11,7 @@ from dexbot.statemachine import StateMachine
 from dexbot.helper import truncate
 from dexbot.strategies.external_feeds.price_feed import PriceFeed
 from dexbot.qt_queue.idle_queue import idle_add
+from dexbot.strategies.base_config import BaseConfig
 
 from events import Events
 import bitshares.exceptions
@@ -25,63 +26,6 @@ from bitshares.price import FilledOrder, Order, UpdateCallOrder
 
 # Number of maximum retries used to retry action before failing
 MAX_TRIES = 3
-
-""" Strategies need to specify their own configuration values, so each strategy can have a class method 'configure' 
-    which returns a list of ConfigElement named tuples.
-    
-    Tuple fields as follows:
-        - Key: The key in the bot config dictionary that gets saved back to config.yml
-        - Type: "int", "float", "bool", "string" or "choice"
-        - Default: The default value, must be same type as the Type defined
-        - Title: Name shown to the user, preferably not too long
-        - Description: Comments to user, full sentences encouraged
-        - Extra:
-              :int: a (min, max, suffix) tuple
-              :float: a (min, max, precision, suffix) tuple
-              :string: a regular expression, entries must match it, can be None which equivalent to .*
-              :bool, ignored
-              :choice: a list of choices, choices are in turn (tag, label) tuples.
-              NOTE: 'labels' get presented to user, and 'tag' is used as the value saved back to the config dict!
-"""
-ConfigElement = collections.namedtuple('ConfigElement', 'key type default title description extra')
-
-""" Strategies have different needs for the details they want to show for the user. These elements help to build a 
-    custom details window for the strategy. 
-
-    Tuple fields as follows:
-        - Type: 'graph', 'text', 'table'
-        - Name: The name of the tab, shows at the top
-        - Title: The title is shown inside the tab
-        - File: Tabs can also show data from files, pass on the file name including the file extension
-                in strategy's `configure_details`. 
-                
-                Below folders and representative file types that inside the folders.
-                
-                Location        File extensions
-                ---------------------------
-                dexbot/graphs   .png, .jpg
-                dexbot/data     .csv
-                dexbot/logs     .log, .txt (.csv, will print as raw data)
-                
-          NOTE: To avoid conflicts with other custom strategies, when generating names for files, use slug or worker's 
-          name when generating files or create custom folders. Add relative path to 'file' parameter if file is in
-          custom folder inside default folders. Like shown below:
-          
-          `DetailElement('log', 'Worker log', 'Log of worker's actions', 'my_custom_folder/example_worker.log')`
-"""
-DetailElement = collections.namedtuple('DetailTab', 'type name title file')
-
-# External exchanges used to calculate center price
-EXCHANGES = [
-    # ('none', 'None. Use Manual or Bitshares DEX Price (default)'),
-    ('gecko', 'Coingecko'),
-    ('waves', 'Waves DEX'),
-    ('kraken', 'Kraken'),
-    ('bitfinex', 'Bitfinex'),
-    ('gdax', 'Gdax'),
-    ('binance', 'Binance')
-]
-
 
 class StrategyBase(Storage, StateMachine, Events):
     """ A strategy based on this class is intended to work in one market. This class contains
@@ -121,7 +65,16 @@ class StrategyBase(Storage, StateMachine, Events):
         They can log events. If a problem occurs they can't fix they should set self.disabled = True and
         throw an exception. The framework catches all exceptions thrown from event handlers and logs appropriately.
     """
+    
+    @classmethod
+    def configure(cls, return_base_config=True):
+        return BaseConfig.configure(return_base_config)
+           
+    @classmethod
+    def configure_details(cls, include_default_tabs=True):
+        return BaseConfig.configure_details(include_default_tabs)
 
+    
     __events__ = [
         'onAccount',
         'onMarketUpdate',
@@ -134,57 +87,6 @@ class StrategyBase(Storage, StateMachine, Events):
         'error_ontick',
     ]
 
-    @classmethod
-    def configure(cls, return_base_config=True):
-        """ Return a list of ConfigElement objects defining the configuration values for this class.
-
-            User interfaces should then generate widgets based on these values, gather data and save back to
-            the config dictionary for the worker.
-
-            NOTE: When overriding you almost certainly will want to call the ancestor and then
-            add your config values to the list.
-
-            :param return_base_config: bool:
-            :return: Returns a list of config elements
-        """
-
-        # Common configs
-        base_config = [
-            ConfigElement('account', 'string', '', 'Account',
-                          'BitShares account name for the bot to operate with',
-                          ''),
-            ConfigElement('market', 'string', 'USD:BTS', 'Market',
-                          'BitShares market to operate on, in the format ASSET:OTHERASSET, for example \"USD:BTS\"',
-                          r'[A-Z\.]+[:\/][A-Z\.]+'),
-            ConfigElement('fee_asset', 'string', 'BTS', 'Fee asset',
-                          'Asset to be used to pay transaction fees',
-                          r'[A-Z\.]+')
-        ]
-
-        if return_base_config:
-            return base_config
-        return []
-
-    @classmethod
-    def configure_details(cls, include_default_tabs=True):
-        """ Return a list of ConfigElement objects defining the configuration values for this class.
-
-            User interfaces should then generate widgets based on these values, gather data and save back to
-            the config dictionary for the worker.
-
-            NOTE: When overriding you almost certainly will want to call the ancestor and then
-            add your config values to the list.
-
-            :param include_default_tabs: bool:
-            :return: Returns a list of Detail elements
-        """
-
-        # Common configs
-        details = []
-
-        if include_default_tabs:
-            return details
-        return []
 
     def __init__(self,
                  name,

--- a/dexbot/strategies/base.py
+++ b/dexbot/strategies/base.py
@@ -153,9 +153,6 @@ class StrategyBase(Storage, StateMachine, Events):
             ConfigElement('account', 'string', '', 'Account',
                           'BitShares account name for the bot to operate with',
                           ''),
-            ConfigElement('wif', 'string', '', 'WIF Key',
-                          'BitShares WIF Key for the bot to operate with',
-                          ''),
             ConfigElement('market', 'string', 'USD:BTS', 'Market',
                           'BitShares market to operate on, in the format ASSET:OTHERASSET, for example \"USD:BTS\"',
                           r'[A-Z\.]+[:\/][A-Z\.]+'),
@@ -243,7 +240,6 @@ class StrategyBase(Storage, StateMachine, Events):
 
         # Get Bitshares account and market for this worker
         self._account = Account(self.worker["account"], full=True, bitshares_instance=self.bitshares)
-        self._wifkey = self.worker.get('wif')
 
         self._market = Market(config["workers"][name]["market"], bitshares_instance=self.bitshares)
 

--- a/dexbot/strategies/base_config.py
+++ b/dexbot/strategies/base_config.py
@@ -1,0 +1,101 @@
+import collections
+
+""" Strategies need to specify their own configuration values, so each strategy can have a class method 'configure' 
+    which returns a list of ConfigElement named tuples.
+    
+    Tuple fields as follows:
+        - Key: The key in the bot config dictionary that gets saved back to config.yml
+        - Type: "int", "float", "bool", "string" or "choice"
+        - Default: The default value, must be same type as the Type defined
+        - Title: Name shown to the user, preferably not too long
+        - Description: Comments to user, full sentences encouraged
+        - Extra:
+              :int: a (min, max, suffix) tuple
+              :float: a (min, max, precision, suffix) tuple
+              :string: a regular expression, entries must match it, can be None which equivalent to .*
+              :bool, ignored
+              :choice: a list of choices, choices are in turn (tag, label) tuples.
+              NOTE: 'labels' get presented to user, and 'tag' is used as the value saved back to the config dict!
+"""
+ConfigElement = collections.namedtuple('ConfigElement', 'key type default title description extra')
+
+""" Strategies have different needs for the details they want to show for the user. These elements help to build a 
+    custom details window for the strategy. 
+
+    Tuple fields as follows:
+        - Type: 'graph', 'text', 'table'
+        - Name: The name of the tab, shows at the top
+        - Title: The title is shown inside the tab
+        - File: Tabs can also show data from files, pass on the file name including the file extension
+                in strategy's `configure_details`. 
+                
+                Below folders and representative file types that inside the folders.
+                
+                Location        File extensions
+                ---------------------------
+                dexbot/graphs   .png, .jpg
+                dexbot/data     .csv
+                dexbot/logs     .log, .txt (.csv, will print as raw data)
+                
+          NOTE: To avoid conflicts with other custom strategies, when generating names for files, use slug or worker's 
+          name when generating files or create custom folders. Add relative path to 'file' parameter if file is in
+          custom folder inside default folders. Like shown below:
+          
+          `DetailElement('log', 'Worker log', 'Log of worker's actions', 'my_custom_folder/example_worker.log')`
+"""
+DetailElement = collections.namedtuple('DetailTab', 'type name title file')
+
+
+class BaseConfig(): 
+
+    @classmethod 
+    def configure(cls, return_base_config=True):
+        """ Return a list of ConfigElement objects defining the configuration values for this class.
+
+            User interfaces should then generate widgets based on these values, gather data and save back to
+            the config dictionary for the worker.
+
+            NOTE: When overriding you almost certainly will want to call the ancestor and then
+            add your config values to the list.
+
+            :param return_base_config: bool:
+            :return: Returns a list of config elements
+        """
+
+        # Common configs
+        base_config = [
+            ConfigElement('account', 'string', '', 'Account',
+                          'BitShares account name for the bot to operate with',
+                          ''),
+            ConfigElement('market', 'string', 'USD:BTS', 'Market',
+                          'BitShares market to operate on, in the format ASSET:OTHERASSET, for example \"USD:BTS\"',
+                          r'[A-Z\.]+[:\/][A-Z\.]+'),
+            ConfigElement('fee_asset', 'string', 'BTS', 'Fee asset',
+                          'Asset to be used to pay transaction fees',
+                          r'[A-Z\.]+')
+        ]
+
+        if return_base_config:
+            return base_config
+        return []
+    
+    @classmethod
+    def configure_details(cls, include_default_tabs=True):
+        """ Return a list of ConfigElement objects defining the configuration values for this class.
+
+            User interfaces should then generate widgets based on these values, gather data and save back to
+            the config dictionary for the worker.
+
+            NOTE: When overriding you almost certainly will want to call the ancestor and then
+            add your config values to the list.
+
+            :param include_default_tabs: bool:
+            :return: Returns a list of Detail elements
+        """
+
+        # Common configs
+        details = []
+
+        if include_default_tabs:
+            return details
+        return []

--- a/dexbot/strategies/relative_config.py
+++ b/dexbot/strategies/relative_config.py
@@ -1,0 +1,95 @@
+from dexbot.strategies.base_config import BaseConfig, ConfigElement, DetailElement
+
+class RelativeConfig(BaseConfig):
+
+    @classmethod 
+    def configure(cls, return_base_config=True):
+        """ Return a list of ConfigElement objects defining the configuration values for this class.
+
+            User interfaces should then generate widgets based on these values, gather data and save back to
+            the config dictionary for the worker.
+
+            NOTE: When overriding you almost certainly will want to call the ancestor and then
+            add your config values to the list.
+
+            :param return_base_config: bool:
+            :return: Returns a list of config elements
+        """
+        # External exchanges used to calculate center price
+        EXCHANGES = [
+            # ('none', 'None. Use Manual or Bitshares DEX Price (default)'),
+            ('gecko', 'Coingecko'),
+            ('waves', 'Waves DEX'),
+            ('kraken', 'Kraken'),
+            ('bitfinex', 'Bitfinex'),
+            ('gdax', 'Gdax'),
+            ('binance', 'Binance')
+        ]
+    
+        relative_orders_config =  [
+            ConfigElement('external_feed', 'bool', False, 'External price feed',
+                          'Use external reference price instead of center price acquired from the market', None),
+            ConfigElement('external_price_source', 'choice', 'gecko', 'External price source',
+                          'The bot will try to get price information from this source', EXCHANGES),
+            ConfigElement('amount', 'float', 1, 'Amount',
+                          'Fixed order size, expressed in quote asset, unless "relative order size" selected',
+                          (0, None, 8, '')),
+            ConfigElement('relative_order_size', 'bool', False, 'Relative order size',
+                          'Amount is expressed as a percentage of the account balance of quote/base asset', None),
+            ConfigElement('spread', 'float', 5, 'Spread',
+                          'The percentage difference between buy and sell', (0, 100, 2, '%')),
+            ConfigElement('dynamic_spread', 'bool', False, 'Dynamic spread',
+                          'Enable dynamic spread which overrides the spread field', None),
+            ConfigElement('market_depth_amount', 'float', 0, 'Market depth',
+                          'From which depth will market spread be measured? (QUOTE amount)',
+                          (0.00000001, 1000000000, 8, '')),
+            ConfigElement('dynamic_spread_factor', 'float', 1, 'Dynamic spread factor',
+                          'How many percent will own spread be compared to market spread?',
+                          (0.01, 1000, 2, '%')),
+            ConfigElement('center_price', 'float', 0, 'Center price',
+                          'Fixed center price expressed in base asset: base/quote', (0, None, 8, '')),
+            ConfigElement('center_price_dynamic', 'bool', True, 'Measure center price from market orders',
+                          'Estimate the center from closest opposite orders or from a depth', None),
+            ConfigElement('center_price_depth', 'float', 0, 'Measurement depth',
+                          'Cumulative quote amount from which depth center price will be measured',
+                          (0.00000001, 1000000000, 8, '')),
+            ConfigElement('center_price_offset', 'bool', False, 'Center price offset based on asset balances',
+                          'Automatically adjust orders up or down based on the imbalance of your assets', None),
+            ConfigElement('manual_offset', 'float', 0, 'Manual center price offset',
+                          "Manually adjust orders up or down. "
+                          "Works independently of other offsets and doesn't override them", (-50, 100, 2, '%')),
+            ConfigElement('reset_on_partial_fill', 'bool', True, 'Reset orders on partial fill',
+                          'Reset orders when buy or sell order is partially filled', None),
+            ConfigElement('partial_fill_threshold', 'float', 30, 'Fill threshold',
+                          'Order fill threshold to reset orders', (0, 100, 2, '%')),
+            ConfigElement('reset_on_price_change', 'bool', False, 'Reset orders on center price change',
+                          'Reset orders when center price is changed more than threshold '
+                          '(set False for external feeds)', None),
+            ConfigElement('price_change_threshold', 'float', 2, 'Price change threshold',
+                          'Define center price threshold to react on', (0, 100, 2, '%')),
+            ConfigElement('custom_expiration', 'bool', False, 'Custom expiration',
+                          'Override order expiration time to trigger a reset', None),
+            ConfigElement('expiration_time', 'int', 157680000, 'Order expiration time',
+                          'Define custom order expiration time to force orders reset more often, seconds',
+                          (30, 157680000, ''))
+        ]
+        
+        if return_base_config:
+            return BaseConfig.configure(return_base_config) + relative_orders_config
+        return []
+    
+
+    @classmethod
+    def configure_details(cls, include_default_tabs=True):
+        """ Return a list of ConfigElement objects defining the configuration values for this class.
+        
+            User interfaces should then generate widgets based on these values, gather data and save back to
+            the config dictionary for the worker.
+
+            NOTE: When overriding you almost certainly will want to call the ancestor and then
+            add your config values to the list.
+        
+            :param include_default_tabs: bool:
+            :return: Returns a list of Detail elements
+        """
+        return BaseConfig.configure_details(include_default_tabs) + []

--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -1,67 +1,21 @@
 import math
 from datetime import datetime, timedelta
 
-from dexbot.strategies.base import StrategyBase, ConfigElement, DetailElement, EXCHANGES
+from dexbot.strategies.base import StrategyBase
+from dexbot.strategies.relative_config import RelativeConfig
 from dexbot.qt_queue.idle_queue import idle_add
-
 
 class Strategy(StrategyBase):
     """ Relative Orders strategy
     """
-
+    
     @classmethod
     def configure(cls, return_base_config=True):
-        return StrategyBase.configure(return_base_config) + [
-            ConfigElement('external_price_source', 'choice', EXCHANGES[0], 'External price source',
-                          'The bot will try to get price information from this source', EXCHANGES),
-            ConfigElement('external_feed', 'bool', False, 'External price feed',
-                          'Use external reference price instead of center price acquired from the market', None),
-            ConfigElement('amount', 'float', 1, 'Amount',
-                          'Fixed order size, expressed in quote asset, unless "relative order size" selected',
-                          (0, None, 8, '')),
-            ConfigElement('relative_order_size', 'bool', False, 'Relative order size',
-                          'Amount is expressed as a percentage of the account balance of quote/base asset', None),
-            ConfigElement('spread', 'float', 5, 'Spread',
-                          'The percentage difference between buy and sell', (0, 100, 2, '%')),
-            ConfigElement('dynamic_spread', 'bool', False, 'Dynamic spread',
-                          'Enable dynamic spread which overrides the spread field', None),
-            ConfigElement('market_depth_amount', 'float', 0, 'Market depth',
-                          'From which depth will market spread be measured? (QUOTE amount)',
-                          (0.00000001, 1000000000, 8, '')),
-            ConfigElement('dynamic_spread_factor', 'float', 1, 'Dynamic spread factor',
-                          'How many percent will own spread be compared to market spread?',
-                          (0.01, 1000, 2, '%')),
-            ConfigElement('center_price', 'float', 0, 'Center price',
-                          'Fixed center price expressed in base asset: base/quote', (0, None, 8, '')),
-            ConfigElement('center_price_dynamic', 'bool', True, 'Measure center price from market orders',
-                          'Estimate the center from closest opposite orders or from a depth', None),
-            ConfigElement('center_price_depth', 'float', 0, 'Measurement depth',
-                          'Cumulative quote amount from which depth center price will be measured',
-                          (0.00000001, 1000000000, 8, '')),
-            ConfigElement('center_price_offset', 'bool', False, 'Center price offset based on asset balances',
-                          'Automatically adjust orders up or down based on the imbalance of your assets', None),
-            ConfigElement('manual_offset', 'float', 0, 'Manual center price offset',
-                          "Manually adjust orders up or down. "
-                          "Works independently of other offsets and doesn't override them", (-50, 100, 2, '%')),
-            ConfigElement('reset_on_partial_fill', 'bool', True, 'Reset orders on partial fill',
-                          'Reset orders when buy or sell order is partially filled', None),
-            ConfigElement('partial_fill_threshold', 'float', 30, 'Fill threshold',
-                          'Order fill threshold to reset orders', (0, 100, 2, '%')),
-            ConfigElement('reset_on_price_change', 'bool', False, 'Reset orders on center price change',
-                          'Reset orders when center price is changed more than threshold '
-                          '(set False for external feeds)', None),
-            ConfigElement('price_change_threshold', 'float', 2, 'Price change threshold',
-                          'Define center price threshold to react on', (0, 100, 2, '%')),
-            ConfigElement('custom_expiration', 'bool', False, 'Custom expiration',
-                          'Override order expiration time to trigger a reset', None),
-            ConfigElement('expiration_time', 'int', 157680000, 'Order expiration time',
-                          'Define custom order expiration time to force orders reset more often, seconds',
-                          (30, 157680000, ''))
-        ]
+        return RelativeConfig.configure(return_base_config)
 
     @classmethod
     def configure_details(cls, include_default_tabs=True):
-        return StrategyBase.configure_details(include_default_tabs) + []
+        return RelativeConfig.configure_details(include_default_tabs)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/dexbot/strategies/staggered_config.py
+++ b/dexbot/strategies/staggered_config.py
@@ -1,0 +1,70 @@
+from dexbot.strategies.base_config import BaseConfig, ConfigElement, DetailElement
+
+class StaggeredConfig(BaseConfig):
+    
+    @classmethod
+    def configure(cls, return_base_config=True):
+        """ Modes description:
+
+            Mountain:
+            - Buy orders same QUOTE
+            - Sell orders same BASE
+
+            Neutral:
+            - Buy orders lower_order_base * sqrt(1 + increment)
+            - Sell orders higher_order_quote * sqrt(1 + increment)
+
+            Valley:
+            - Buy orders same BASE
+            - Sell orders same QUOTE
+
+            Buy slope:
+            - All orders same BASE (profit comes in QUOTE)
+
+            Sell slope:
+            - All orders same QUOTE (profit made in BASE)
+        """
+        modes = [
+            ('mountain', 'Mountain'),
+            ('neutral', 'Neutral'),
+            ('valley', 'Valley'),
+            ('buy_slope', 'Buy Slope'),
+            ('sell_slope', 'Sell Slope')
+        ]
+
+        return BaseConfig.configure(return_base_config) + [
+            ConfigElement(
+                'mode', 'choice', 'neutral', 'Strategy mode',
+                'How to allocate funds and profits. Doesn\'t effect existing orders, only future ones', modes),
+            ConfigElement(
+                'spread', 'float', 6, 'Spread',
+                'The percentage difference between buy and sell', (0, None, 2, '%')),
+            ConfigElement(
+                'increment', 'float', 4, 'Increment',
+                'The percentage difference between staggered orders', (0, None, 2, '%')),
+            ConfigElement(
+                'center_price_dynamic', 'bool', True, 'Market center price',
+                'Begin strategy with center price obtained from the market. Use with mature markets', None),
+            ConfigElement(
+                'center_price', 'float', 0, 'Manual center price',
+                'In an immature market, give a center price manually to begin with. BASE/QUOTE',
+                (0, 1000000000, 8, '')),
+            ConfigElement(
+                'lower_bound', 'float', 1, 'Lower bound',
+                'The bottom price in the range',
+                (0, 1000000000, 8, '')),
+            ConfigElement(
+                'upper_bound', 'float', 1000000, 'Upper bound',
+                'The top price in the range',
+                (0, 1000000000, 8, '')),
+            ConfigElement(
+                'instant_fill', 'bool', True, 'Allow instant fill',
+                'Allow to execute orders by market', None),
+            ConfigElement(
+                'operational_depth', 'int', 10, 'Operational depth',
+                'Order depth to maintain on books', (2, 9999999, None))
+        ]
+
+    @classmethod
+    def configure_details(cls, include_default_tabs=True):
+        return BaseConfig.configure_details(include_default_tabs) + []

--- a/dexbot/strategies/staggered_orders.py
+++ b/dexbot/strategies/staggered_orders.py
@@ -8,79 +8,20 @@ from functools import reduce
 from bitshares.dex import Dex
 from bitshares.amount import Amount
 
-from dexbot.strategies.base import StrategyBase, ConfigElement, DetailElement
-
+from dexbot.strategies.base import StrategyBase
+from dexbot.strategies.staggered_config import StaggeredConfig
 
 class Strategy(StrategyBase):
     """ Staggered Orders strategy """
 
     @classmethod
     def configure(cls, return_base_config=True):
-        """ Modes description:
-
-            Mountain:
-            - Buy orders same QUOTE
-            - Sell orders same BASE
-
-            Neutral:
-            - Buy orders lower_order_base * sqrt(1 + increment)
-            - Sell orders higher_order_quote * sqrt(1 + increment)
-
-            Valley:
-            - Buy orders same BASE
-            - Sell orders same QUOTE
-
-            Buy slope:
-            - All orders same BASE (profit comes in QUOTE)
-
-            Sell slope:
-            - All orders same QUOTE (profit made in BASE)
-        """
-        modes = [
-            ('mountain', 'Mountain'),
-            ('neutral', 'Neutral'),
-            ('valley', 'Valley'),
-            ('buy_slope', 'Buy Slope'),
-            ('sell_slope', 'Sell Slope')
-        ]
-
-        return StrategyBase.configure(return_base_config) + [
-            ConfigElement(
-                'mode', 'choice', 'neutral', 'Strategy mode',
-                'How to allocate funds and profits. Doesn\'t effect existing orders, only future ones', modes),
-            ConfigElement(
-                'spread', 'float', 6, 'Spread',
-                'The percentage difference between buy and sell', (0, None, 2, '%')),
-            ConfigElement(
-                'increment', 'float', 4, 'Increment',
-                'The percentage difference between staggered orders', (0, None, 2, '%')),
-            ConfigElement(
-                'center_price_dynamic', 'bool', True, 'Market center price',
-                'Begin strategy with center price obtained from the market. Use with mature markets', None),
-            ConfigElement(
-                'center_price', 'float', 0, 'Manual center price',
-                'In an immature market, give a center price manually to begin with. BASE/QUOTE',
-                (0, 1000000000, 8, '')),
-            ConfigElement(
-                'lower_bound', 'float', 1, 'Lower bound',
-                'The bottom price in the range',
-                (0, 1000000000, 8, '')),
-            ConfigElement(
-                'upper_bound', 'float', 1000000, 'Upper bound',
-                'The top price in the range',
-                (0, 1000000000, 8, '')),
-            ConfigElement(
-                'instant_fill', 'bool', True, 'Allow instant fill',
-                'Allow to execute orders by market', None),
-            ConfigElement(
-                'operational_depth', 'int', 10, 'Operational depth',
-                'Order depth to maintain on books', (2, 9999999, None))
-        ]
+        return StaggeredConfig.configure(return_base_config)
 
     @classmethod
     def configure_details(cls, include_default_tabs=True):
-        return StrategyBase.configure_details(include_default_tabs) + []
-
+        return StaggeredConfig.configure_details(include_default_tabs)
+    
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/dexbot/strategies/strategy_config.py
+++ b/dexbot/strategies/strategy_config.py
@@ -1,0 +1,42 @@
+from dexbot.strategies.base_config import BaseConfig, ConfigElement, DetailElement
+
+class StrategyConfig(BaseConfig):
+    """ this is the configuration template for the strategy_template class
+    """
+
+    @classmethod
+    def configure(cls, return_base_config=True):
+        """ This function is used to auto generate fields for GUI
+        
+            :param return_base_config: If base config is used in addition to this configuration.
+            :return: List of ConfigElement(s)
+        """
+
+        """ As a demonstration this template has two fields in the worker configuration. Upper and lower bound. 
+            Documentation of ConfigElements can be found from base.py.
+        """
+        return BaseConfig.configure(return_base_config) + [
+            ConfigElement('lower_bound', 'float', 1, 'Lower bound',
+                          'The bottom price in the range',
+                          (0, 10000000, 8, '')),
+            ConfigElement('upper_bound', 'float', 10, 'Upper bound',
+                          'The top price in the range',
+                          (0, 10000000, 8, '')),
+        ]
+
+
+    @classmethod
+    def configure_details(cls, include_default_tabs=True):
+        """ This function defines the tabs for detailed view of the worker. Further documentation is found in base.py
+
+            :param include_default_tabs: If default tabs are included as well
+            :return: List of DetailElement(s)
+
+            NOTE: Add files to user data folders to see how they behave as an example.
+        """
+        return BaseConfig.configure_details(include_default_tabs) + [
+            DetailElement('graph', 'Graph', 'Graph', 'graph.jpg'),
+            DetailElement('table', 'Orders', 'Data from csv file', 'example.csv'),
+            DetailElement('text', 'Log', 'Log data', 'example.log')
+        ]
+    

--- a/dexbot/strategies/strategy_template.py
+++ b/dexbot/strategies/strategy_template.py
@@ -2,7 +2,8 @@
 import math
 
 # Project imports
-from dexbot.strategies.base import StrategyBase, ConfigElement, DetailElement
+from dexbot.strategies.base import StrategyBase
+from dexbot.strategies.strategy_config import StrategyConfig
 from dexbot.qt_queue.idle_queue import idle_add
 
 # Third party imports
@@ -10,11 +11,10 @@ from bitshares.market import Market
 
 STRATEGY_NAME = 'Strategy Template'
 
-
 class Strategy(StrategyBase):
     """ <strategy_name>
 
-        Replace <stragegy_name> with the name of the strategy.
+        Replace <strategy_name> with the name of the strategy.
 
         This is a template strategy which can be used to create custom strategies easier. The base for the strategy is
         ready. It is recommended comment the strategy and functions to help other developers to make changes.
@@ -40,42 +40,14 @@ class Strategy(StrategyBase):
 
         NOTE: Change this comment section to describe the strategy.
     """
-
     @classmethod
     def configure(cls, return_base_config=True):
-        """ This function is used to auto generate fields for GUI
-
-            :param return_base_config: If base config is used in addition to this configuration.
-            :return: List of ConfigElement(s)
-        """
-
-        """ As a demonstration this template has two fields in the worker configuration. Upper and lower bound. 
-            Documentation of ConfigElements can be found from base.py.
-        """
-        return StrategyBase.configure(return_base_config) + [
-            ConfigElement('lower_bound', 'float', 1, 'Lower bound',
-                          'The bottom price in the range',
-                          (0, 10000000, 8, '')),
-            ConfigElement('upper_bound', 'float', 10, 'Upper bound',
-                          'The top price in the range',
-                          (0, 10000000, 8, '')),
-        ]
+        return StrategyConfig.configure(return_base_config)
 
     @classmethod
     def configure_details(cls, include_default_tabs=True):
-        """ This function defines the tabs for detailed view of the worker. Further documentation is found in base.py
-
-            :param include_default_tabs: If default tabs are included as well
-            :return: List of DetailElement(s)
-
-            NOTE: Add files to user data folders to see how they behave as an example.
-        """
-        return StrategyBase.configure_details(include_default_tabs) + [
-            DetailElement('graph', 'Graph', 'Graph', 'graph.jpg'),
-            DetailElement('table', 'Orders', 'Data from csv file', 'example.csv'),
-            DetailElement('text', 'Log', 'Log data', 'example.log')
-        ]
-
+        return StrategyConfig.configure_details(return_base_config)
+    
     def __init__(self, *args, **kwargs):
         # Initializes StrategyBase class
         super().__init__(*args, **kwargs)

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -103,7 +103,11 @@ def unlock(f):
                         sys.exit(78)  # 'configuration error' in sysexits.h
                     pwd = click.prompt(
                         "Current Wallet Passphrase", hide_input=True)
-                ctx.bitshares.wallet.unlock(pwd)
+                try:
+                    ctx.bitshares.wallet.unlock(pwd)
+                except Exception as exception:
+                    log.critical("Password error, exiting")
+                    sys.exit(78)
             else:
                 if systemd:
                     # No user available to interact with
@@ -114,7 +118,7 @@ def unlock(f):
                     "Wallet Encryption Passphrase",
                     hide_input=True,
                     confirmation_prompt=True)
-                ctx.bitshares.wallet.create(pwd)
+                ctx.bitshares.wallet.create(pwd)                
         return ctx.invoke(f, *args, **kwargs)
     return update_wrapper(new_func, f)
 


### PR DESCRIPTION
this is a cli-configure refactor. pulling to codaone 458-refactor-cli so vvk can debug. Feel free to make any changes as needed you do not need my permission.

** New Menu Item Features**

- List Workers: This is a new menu item. It also allows the user to view config details. 
- For Add New Worker - WIF key added, worker name cannot be blank, account name cannot be blank
- For Editing Worker - you can change the account, as was before. However, the WIF cannot be edited. This mirrors GUI behavior. 
- Add Node: allows user to enter new node to the top of heap 
- Add Bitshares Account
- Show Bitshares Accounts that have already been added
- Help link
- Add Node

**Refactoring:** 
-  Add Config Helper class, handles most of the logic for account validation
-  ConfigElements and Config Details methods pulled out of strategies. Base.py is 1400 lines long.

**Notes:**

-  Form Validation for the cli-configure prior to this was non-existent. A few have been added but you can do more in the future. 
-  There are no checks if the user decides to use more than one bitshares accounts with a worker. 
-  There is no delete bitshares account yet. Also GUI also does not have this. 
-  There is no delete node feature yet.

**Future Todo:**

-  Put all related cli files into one sub-directory: cli.py cli_conf.py, cli_helper.py whiptail.py 
-  Save Configuration without having to exit. Right now the only way the config can be saved is if you exit properly. Cancel does not save.
-  Whiptail buttons should be customized so that you have “Exit” or “Save” instead of the default “OK” or “Cancel”
-  Delete nodes.
-  Edit nodes
-  Delete bitshares accounts, and any workers associated with them.
-  Strategies still keep their original configure and configure_details methods, but pull the data from config classes. if we want to completely remove the references, some editing of the gui/cli needed. 
 