### PR TITLE
Update pybitshares to version 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests>=2.20.0
 yarl==1.1.0
 ccxt==1.17.434
 pywaves==0.8.20
-bitshares==0.2.1
+bitshares==0.3.0
 uptick==0.2.1
 ruamel.yaml>=0.15.37
 appdirs>=1.4.3


### PR DESCRIPTION
Bumping up the required version number for pybitshares to 0.3.0