### PR TITLE
Fix install bug on Linux and Windows

### DIFF
--- a/dexbot/config_validator.py
+++ b/dexbot/config_validator.py
@@ -49,8 +49,8 @@ class ConfigValidator:
             return False
 
         # Load all accounts with corresponding public key from the blockchain
-        accounts = wallet.getAllAccounts(pubkey)
-        account_names = [account['name'] for account in accounts]
+        accounts = wallet.getAccountsFromPublicKey(pubkey)
+        account_names = [Account(account)['name'] for account in accounts]
 
         if account in account_names:
             return True

--- a/dexbot/strategies/base.py
+++ b/dexbot/strategies/base.py
@@ -10,7 +10,7 @@ from dexbot.statemachine import StateMachine
 from dexbot.helper import truncate
 from dexbot.strategies.external_feeds.price_feed import PriceFeed
 from dexbot.qt_queue.idle_queue import idle_add
-from .config_parts.base_config import BaseConfig
+from dexbot.strategies.config_parts.base_config import BaseConfig
 
 from events import Events
 import bitshares.exceptions

--- a/dexbot/strategies/config_parts/base_config.py
+++ b/dexbot/strategies/config_parts/base_config.py
@@ -46,7 +46,7 @@ ConfigElement = collections.namedtuple('ConfigElement', 'key type default title 
 DetailElement = collections.namedtuple('DetailTab', 'type name title file')
 
 
-class BaseConfig():
+class BaseConfig:
 
     @classmethod
     def configure(cls, return_base_config=True):

--- a/dexbot/strategies/config_parts/relative_config.py
+++ b/dexbot/strategies/config_parts/relative_config.py
@@ -1,4 +1,4 @@
-from .base_config import BaseConfig, ConfigElement
+from dexbot.strategies.config_parts.base_config import BaseConfig, ConfigElement
 
 
 class RelativeConfig(BaseConfig):

--- a/dexbot/strategies/config_parts/staggered_config.py
+++ b/dexbot/strategies/config_parts/staggered_config.py
@@ -1,4 +1,4 @@
-from .base_config import BaseConfig, ConfigElement
+from dexbot.strategies.config_parts.base_config import BaseConfig, ConfigElement
 
 
 class StaggeredConfig(BaseConfig):

--- a/dexbot/strategies/config_parts/strategy_config.py
+++ b/dexbot/strategies/config_parts/strategy_config.py
@@ -1,4 +1,4 @@
-from .base_config import BaseConfig, ConfigElement, DetailElement
+from dexbot.strategies.config_parts.base_config import BaseConfig, ConfigElement, DetailElement
 
 
 class StrategyConfig(BaseConfig):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ yarl==1.1.0
 ccxt==1.17.434
 pywaves==0.8.20
 bitshares==0.3.0
-uptick==0.2.1
+uptick==0.2.2
 ruamel.yaml>=0.15.37
 appdirs>=1.4.3
 pycryptodomex==3.6.4


### PR DESCRIPTION
Fixes an error reportedly on Windows and Linux when installing DEXBot.

`ModuleNotFoundError: No module named 'dexbot.strategies.config_parts'` was caused by missing `__init__.py` from `config_part` package.