### PR TITLE
Fix installation ModuleNotFoundError

### DIFF
--- a/dexbot/strategies/config_parts/base_config.py
+++ b/dexbot/strategies/config_parts/base_config.py
@@ -3,7 +3,7 @@ import collections
 """ Strategies need to specify their own configuration values, so each strategy can have a class method 'configure'
     which returns a list of ConfigElement named tuples.
 
-    Tuple fields as follows:
+    Tuple fields as fgitollows:
         - Key: The key in the bot config dictionary that gets saved back to config.yml
         - Type: "int", "float", "bool", "string" or "choice"
         - Default: The default value, must be same type as the Type defined

--- a/dexbot/strategies/config_parts/base_config.py
+++ b/dexbot/strategies/config_parts/base_config.py
@@ -3,7 +3,7 @@ import collections
 """ Strategies need to specify their own configuration values, so each strategy can have a class method 'configure'
     which returns a list of ConfigElement named tuples.
 
-    Tuple fields as fgitollows:
+    Tuple fields as follows:
         - Key: The key in the bot config dictionary that gets saved back to config.yml
         - Type: "int", "float", "bool", "string" or "choice"
         - Default: The default value, must be same type as the Type defined

--- a/dexbot/strategies/config_parts/base_config.py
+++ b/dexbot/strategies/config_parts/base_config.py
@@ -46,7 +46,7 @@ ConfigElement = collections.namedtuple('ConfigElement', 'key type default title 
 DetailElement = collections.namedtuple('DetailTab', 'type name title file')
 
 
-class BaseConfig():
+class BaseConfig:
 
     @classmethod
     def configure(cls, return_base_config=True):

--- a/dexbot/strategies/config_parts/relative_config.py
+++ b/dexbot/strategies/config_parts/relative_config.py
@@ -1,4 +1,4 @@
-from .base_config import BaseConfig, ConfigElement
+from dexbot.strategies.config_parts.base_config import BaseConfig, ConfigElement
 
 
 class RelativeConfig(BaseConfig):

--- a/dexbot/strategies/config_parts/staggered_config.py
+++ b/dexbot/strategies/config_parts/staggered_config.py
@@ -1,4 +1,4 @@
-from .base_config import BaseConfig, ConfigElement
+from dexbot.strategies.config_parts.base_config import BaseConfig, ConfigElement
 
 
 class StaggeredConfig(BaseConfig):

--- a/dexbot/strategies/config_parts/strategy_config.py
+++ b/dexbot/strategies/config_parts/strategy_config.py
@@ -1,4 +1,4 @@
-from .base_config import BaseConfig, ConfigElement, DetailElement
+from dexbot.strategies.config_parts.base_config import BaseConfig, ConfigElement, DetailElement
 
 
 class StrategyConfig(BaseConfig):


### PR DESCRIPTION
Fixes an error reportedly on Windows and Linux when installing DEXBot.

`ModuleNotFoundError: No module named 'dexbot.strategies.config_parts'` was caused by missing `__init__.py` from `config_part` package.