### PR TITLE
Change default logfile path for cli

### DIFF
--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -7,10 +7,13 @@ from functools import update_wrapper
 
 import click
 from ruamel import yaml
+from appdirs import user_data_dir
+
 from bitshares import BitShares
 from bitshares.instance import set_shared_bitshares_instance
 from bitshares.exceptions import WrongMasterPasswordException
 
+from dexbot import VERSION, APP_NAME, AUTHOR
 from dexbot.config import Config
 
 log = logging.getLogger(__name__)
@@ -47,8 +50,12 @@ def verbose(f):
         # Logging to a file
         filename = ctx.obj.get('logfile')
         if not filename:
-            # By default, log to a file located where the script is
-            filename = os.path.join(os.path.dirname(sys.argv[0]), 'dexbot.log')
+            # By default, log to a user data dir
+            data_dir = user_data_dir(APP_NAME, AUTHOR)
+            filename = os.path.join(data_dir, 'dexbot.log')
+        # Print logfile using main logger
+        logging.getLogger("dexbot").info('Dexbot version {}, logfile: {}'.format(VERSION, filename))
+
         fh = logging.FileHandler(filename)
         fh.setFormatter(formatter2)
         logger.addHandler(fh)


### PR DESCRIPTION
In b3e8ff104abbf3804dee761a0508f6c1a86c7816 default logfile was changed
to the same directory where the cli executable is. This is a wrong
approach as dexbot can be installed in multiple ways. System-wide
install will put the binary into /usr/bin/dexbot-cli. Applicateion must
not try to log into /usr/bin/.

This change makes logging consistent with GUI, which stores the log into
user data directory, like ~/.local/share/dexbot/dexbot.log

Closes: #490, #540