### PR TITLE
Requirements.txt update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ uptick==0.2.1
 ruamel.yaml>=0.15.37
 appdirs>=1.4.3
 pycryptodomex==3.6.4
-websocket-client==0.54.0
+websocket-client==0.56.0
 sdnotify==0.3.2
 sqlalchemy==1.3.0
 click==7.0


### PR DESCRIPTION
update websocket-client to 0.56 to be compatible with graphenelib 1.1.18 requirement

https://t.me/DEXBOTbts/31269