### PR TITLE
Unlocking the wallet with a Docker secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ To run in unattended mode you need to provide wallet passphrase:
 docker run -d --name dexbot -e UNLOCK=pass -v `pwd`/dexbot-config:/home/dexbot/.config/dexbot -v `pwd`/dexbot-data:/home/dexbot/.local/share dexbot/dexbot:latest dexbot-cli run
 ```
 
+Assuming you have created a Docker secret named "passphrase" in your swarm, you can also get it from there:
+
+```
+printf <pass> | docker secret create passphrase -
+docker run -d --name dexbot -e UNLOCK=/run/secrets/passphrase -v `pwd`/dexbot-config:/home/dexbot/.config/dexbot -v `pwd`/dexbot-data:/home/dexbot/.local/share dexbot/dexbot:latest dexbot-cli run
+```
+
 ## Getting help
 
 Join the [Telegram Chat for DEXBot](https://t.me/DEXBOTbts).

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -110,7 +110,7 @@ def unlock(f):
             if ctx.bitshares.wallet.created():
                 if "UNLOCK" in os.environ:
                     pwd = os.environ["UNLOCK"]
-                    if (pwd[:12] == "/run/secrets"):
+                    if pwd[:12] == "/run/secrets":
                         pwd = open(pwd).read()
                 else:
                     if systemd:

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -110,6 +110,8 @@ def unlock(f):
             if ctx.bitshares.wallet.created():
                 if "UNLOCK" in os.environ:
                     pwd = os.environ["UNLOCK"]
+                    if (pwd[:12] == "/run/secrets"):
+                        pwd = open(pwd).read()
                 else:
                     if systemd:
                         # No user available to interact with


### PR DESCRIPTION
This allows using DEXBot in Docker Swarm more securely using Docker secrets.
In order to try this out, simply create a file `passphrase.secret` containing the passphrase, then use the following `docker-compose.yml`

```
version: '3.6'

services:
  dexbot:
    build: .
    networks:
      - develop
    volumes:
      - ./dexbot-data:/home/dexbot/.local/share
      - ./dexbot-config:/home/dexbot/.config/dexbot
    environment:
      UNLOCK: "/run/secrets/passphrase"
    secrets:
      - passphrase
    command: dexbot-cli run

secrets:
  passphrase:
    file: ./passphrase.secret

networks:
  develop:
    driver: bridge
```