### PR TITLE
Add missing hidden imports

### DIFF
--- a/cli.spec
+++ b/cli.spec
@@ -10,6 +10,7 @@ hiddenimports_strategies = [
     'dexbot.strategies.echo',
     'dexbot.strategies.relative_orders',
     'dexbot.strategies.staggered_orders',
+    'dexbot.strategies.king_of_the_hill',
     'dexbot.strategies.storagedemo',
     'dexbot.strategies.walls',
 ]

--- a/gui.spec
+++ b/gui.spec
@@ -10,6 +10,7 @@ hiddenimports_strategies = [
     'dexbot.strategies.echo',
     'dexbot.strategies.relative_orders',
     'dexbot.strategies.staggered_orders',
+    'dexbot.strategies.king_of_the_hill',
     'dexbot.strategies.storagedemo',
     'dexbot.strategies.walls',
     'dexbot.views.ui.tabs',


### PR DESCRIPTION
Fix the problem on Windows not being able to load the KOTH strategy.

Tested as working solution from Appveyor artifacts.