### PR TITLE
error on wallet.getAccountsFromPublicKey

### DIFF
--- a/dexbot/cli_conf.py
+++ b/dexbot/cli_conf.py
@@ -454,7 +454,7 @@ def list_accounts(bitshares_instance):
         :return: list of tuples (int, 'account_name - key_type')
     """
     accounts = []
-    pubkeys = bitshares_instance.wallet.getPublicKeys(current=True)
+    pubkeys = bitshares_instance.wallet.getPublicKeys()
 
     for pubkey in pubkeys:
         account_ids = bitshares_instance.wallet.getAccountsFromPublicKey(pubkey)


### PR DESCRIPTION
Removed `current=True` which throws Type error

> list_accounts
>     pubkeys = bitshares_instance.wallet.getPublicKeys(current=True)
> TypeError: getPublicKeys() got an unexpected keyword argument 'current’