### PR TITLE
[#664] Add ping into image, as it's required for node checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV CONFIG_DATA $HOME_PATH/.config
 RUN set -xe ;\
     apt-get update ;\
     # Prepare dependencies
-    apt-get install -y --no-install-recommends gcc make libssl-dev python3-pip python3-dev python3-setuptools \
+    apt-get install -y --no-install-recommends iputils-ping gcc make libssl-dev python3-pip python3-dev python3-setuptools \
         python3-async whiptail git ;\
     apt-get clean ;\
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Quick fix for docker image on `0.15.5` release to avoid error:
```
FileNotFoundError: [Errno 2] No such file or directory: 'ping': 'ping'
```

Closes #664 