### PR TITLE
Fix getting last own trade price in RO

### DIFF
--- a/dexbot/strategies/relative_orders.py
+++ b/dexbot/strategies/relative_orders.py
@@ -634,11 +634,17 @@ class Strategy(StrategyBase):
         for entry in history:
             trade = entry['op'][1]
             # Look for first trade in worker's market
-            if trade['pays']['asset_id'] == self.market['base']['id']:  # Buy order
+            if (
+                trade['pays']['asset_id'] == self.market['base']['id']
+                and trade['receives']['asset_id'] == self.market['quote']['id']
+            ):  # Buy order
                 base = trade['fill_price']['base']['amount'] / 10 ** self.market['base']['precision']
                 quote = trade['fill_price']['quote']['amount'] / 10 ** self.market['quote']['precision']
                 break
-            elif trade['pays']['asset_id'] == self.market['quote']['id']:  # Sell order
+            elif (
+                trade['pays']['asset_id'] == self.market['quote']['id']
+                and trade['receives']['asset_id'] == self.market['base']['id']
+            ):  # Sell order
                 base = trade['fill_price']['quote']['amount'] / 10 ** self.market['base']['precision']
                 quote = trade['fill_price']['base']['amount'] / 10 ** self.market['quote']['precision']
                 break

--- a/tests/strategies/relative_orders/conftest.py
+++ b/tests/strategies/relative_orders/conftest.py
@@ -20,7 +20,7 @@ def assets(create_asset):
 
 
 @pytest.fixture(scope='module')
-def base_account(assets, prepare_account, ro_worker_name):
+def base_account(assets, prepare_account):
     """ Factory to generate random account with pre-defined balances
     """
 
@@ -204,7 +204,7 @@ def config_multiple_workers_1(bitshares, account):
             'ro-worker-2': {
                 'account': '{}'.format(account),
                 'amount': 1.0,
-                'center_price': 1,
+                'center_price': 10,  # note price difference
                 'center_price_depth': 0.0,
                 'center_price_dynamic': False,
                 'center_price_offset': False,


### PR DESCRIPTION
Add an explicit check if trade belongs to current market. This fixes a
situation when account is used by multiple workers with asset
intersections. Thus a wrong trade (from different market) may be used
resulting in incirrect price and further trades.