### PR TITLE
fix requirements so compatible with graphene and uptick

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@ pyinstaller==3.4
 click-datetime==0.2
 cryptography==2.3
 aiohttp==3.0.1
-requests>=2.20.0
+requests==2.21.0
 yarl==1.1.0
 ccxt==1.17.434
 pywaves==0.8.20
-git+https://github.com/Codaone/python-bitshares.git@0c9bf5ef3808572b7a10dfc32615906083e6b8ff#egg=bitshares
 git+https://github.com/Codaone/python-graphenelib.git@ba3702a25498f56a8ade8b855b812e7ec00311e2#egg=graphenelib
-uptick==0.2.1
+git+https://github.com/Codaone/python-bitshares.git@0c9bf5ef3808572b7a10dfc32615906083e6b8ff#egg=bitshares
+uptick==0.2.4
 ruamel.yaml>=0.15.37
 appdirs>=1.4.3
 pycryptodomex==3.6.4


### PR DESCRIPTION
Requests must be locked to 2.21 in order to prevent conflict with graphene and uptick. 
Uptick must be upgraded to 0.2.4 in order for commands such as uptick commands such as `listaccounts` and `--version` to work without throwing errors. 

Order of install:  1. requests 2. graphenelib 3. bitshares 4. uptick. 

requests==2.21.0
uptick==0.2.4

$ uptick --version 
+-------------+---------+
| name        | version |
+-------------+---------+
| uptick      | 0.2.4   |
| bitshares   | 0.3.2   |
| graphenelib | 1.1.18  |
+-------------+---------+
