### PR TITLE
add cancel all market orders option to cli. change host_ip 

### DIFF
--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -5,7 +5,6 @@ import os.path
 import signal
 import sys
 
-#from uptick.decorators import unlock, online
 from uptick.decorators import online
 import bitshares.exceptions
 import graphenecommon.exceptions
@@ -202,9 +201,9 @@ def cancel(ctx, market, account):
         else:
             click.echo(f'No orders to cancel! {market} for account: {account}')
 
-    except (bitshares.exceptions.AssetDoesNotExistsException):
+    except bitshares.exceptions.AssetDoesNotExistsException:
         click.echo(f"Asset does not exist: {market}")
-    except (graphenecommon.exceptions.AccountDoesNotExistsException):
+    except graphenecommon.exceptions.AccountDoesNotExistsException:
         click.echo(f"Account does not exist: {account}")
 
 

--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -5,6 +5,12 @@ import os.path
 import signal
 import sys
 
+#from uptick.decorators import unlock, online
+from uptick.decorators import online
+import bitshares.exceptions
+import graphenecommon.exceptions
+from bitshares.market import Market
+
 from dexbot.config import Config, DEFAULT_CONFIG_FILE
 from dexbot.cli_conf import SYSTEMD_SERVICE_NAME, get_whiptail, setup_systemd
 from dexbot.helper import initialize_orders_log, initialize_data_folders
@@ -166,6 +172,40 @@ def configure(ctx):
     if config.get('systemd_status', 'disabled') == 'enabled':
         click.echo("Starting dexbot daemon")
         os.system("systemctl --user start dexbot")
+
+
+@main.command()
+@click.option("--account", default=None)
+@click.argument("market")
+@click.pass_context
+@online
+@unlock
+def cancel(ctx, market, account):
+    """
+    Cancel Orders in Mkt, (Eg: cancel USD/BTS --account name)
+
+    :param ctx: context
+    :param market: market e.g. USD/BTS
+    :param account: name of your bitshares acct
+    :return: Success or Fail message
+    """
+    try:
+        my_market = Market(market)
+        ctx.bitshares.bundle = True
+        my_market.cancel([
+            x["id"] for x in my_market.accountopenorders(account)
+        ], account=account)
+        response = ctx.bitshares.txbuffer.broadcast()
+        log.info(response)
+        if response is not None:
+            click.echo(f'Cancelled all orders on Market: {market} for account: {account}')
+        else:
+            click.echo(f'No orders to cancel! {market} for account: {account}')
+
+    except (bitshares.exceptions.AssetDoesNotExistsException):
+        click.echo(f"Asset does not exist: {market}")
+    except (graphenecommon.exceptions.AccountDoesNotExistsException):
+        click.echo(f"Account does not exist: {account}")
 
 
 def worker_job(worker, job):

--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -197,14 +197,14 @@ def cancel(ctx, market, account):
         response = ctx.bitshares.txbuffer.broadcast()
         log.info(response)
         if response is not None:
-            click.echo(f'Cancelled all orders on Market: {market} for account: {account}')
+            log.info(f'Cancelled all orders on Market: {market} for account: {account}')
         else:
-            click.echo(f'No orders to cancel! {market} for account: {account}')
+            log.info(f'No orders to cancel! {market} for account: {account}')
 
     except bitshares.exceptions.AssetDoesNotExistsException:
-        click.echo(f"Asset does not exist: {market}")
+        log.info(f"Asset does not exist: {market}")
     except graphenecommon.exceptions.AccountDoesNotExistsException:
-        click.echo(f"Account does not exist: {account}")
+        log.info(f"Account does not exist: {account}")
 
 
 def worker_job(worker, job):

--- a/dexbot/node_manager.py
+++ b/dexbot/node_manager.py
@@ -15,7 +15,7 @@ logging.basicConfig(
 )
 
 max_timeout = 2.0  # default ping time is set to 2s. use for internal testing.
-host_ip = '8.8.8.8'  # default host to ping to check internet
+host_ip = '1.1.1.1'  # default host to ping to check internet
 
 
 def ping(host, network_timeout=3):

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -98,7 +98,7 @@ def chain(f):
         nodelist = ctx.config["node"]
         timeout = int(ctx.obj.get("sortnodes"))
 
-        host_ip = '8.8.8.8'
+        host_ip = '1.1.1.1'
         if ping(host_ip, 3) is False:
             click.echo("internet NOT available! Please check your connection!")
             log.critical("Internet not available, exiting")


### PR DESCRIPTION
- Added option to allow user to cancel all market orders for account on dexbot-cli . 
- Todo: Option should be added to to dexbot-gui (for joelvai)
- Also corrected host_ip from 8.8.8.8 to 1.1.1.1, in cases where prior maybe blocked, latter better choice. 