### PR TITLE
Nodelist reset

### DIFF
--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -13,7 +13,7 @@ from dexbot.ui import (
     chain,
     unlock,
     configfile,
-    resetnodes
+    reset_nodes
 )
 
 from .worker import WorkerInfrastructure
@@ -87,8 +87,8 @@ def main(ctx, **kwargs):
 
 @main.command()
 @click.pass_context
-@resetnodes
-def resetnodes():
+@reset_nodes
+def resetnodes(ctx):
     """
     Reset nodes to the default list, use -s option to sort
     """

--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -88,11 +88,12 @@ def main(ctx, **kwargs):
 @main.command()
 @click.pass_context
 @resetnodes
-def resetnodes(ctx):
+def resetnodes():
     """
-    Reset nodes to the default list, use -s to sort
+    Reset nodes to the default list, use -s option to sort
     """
     log.info("Resetting node list in config.yml to default list")
+    log.info("To sort nodes by timeout, use: `dexbot-cli -s 2 resetnodes`")
 
 
 @main.command()

--- a/dexbot/cli.py
+++ b/dexbot/cli.py
@@ -12,7 +12,8 @@ from dexbot.ui import (
     verbose,
     chain,
     unlock,
-    configfile
+    configfile,
+    resetnodes
 )
 
 from .worker import WorkerInfrastructure
@@ -82,6 +83,16 @@ def main(ctx, **kwargs):
     ctx.obj = {}
     for k, v in kwargs.items():
         ctx.obj[k] = v
+
+
+@main.command()
+@click.pass_context
+@resetnodes
+def resetnodes(ctx):
+    """
+    Reset nodes to the default list, use -s to sort
+    """
+    log.info("Resetting node list in config.yml to default list")
 
 
 @main.command()

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -163,7 +163,7 @@ def unlock(f):
     return update_wrapper(new_func, f)
 
 
-def resetnodes(f):
+def reset_nodes(f):
     @click.pass_context
     def new_func(ctx, *args, **kwargs):
         if not os.path.isfile(ctx.obj["configfile"]):

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -96,9 +96,9 @@ def sort_nodes(ctx):
     nodelist = ctx.config["node"]
     timeout = int(ctx.obj.get("sortnodes"))
 
-    host_ip = '1.1.1.1'
+    host_ip = '8.8.8.8'
     if ping(host_ip, 3) is False:
-        click.echo("internet NOT available! Please check your connection!")
+        click.echo("Internet NOT available! Please check your connection!")
         log.critical("Internet not available, exiting")
         sys.exit(78)
 

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -92,23 +92,27 @@ def verbose(f):
     return update_wrapper(new_func, f)
 
 
+def sort_nodes(ctx):
+    nodelist = ctx.config["node"]
+    timeout = int(ctx.obj.get("sortnodes"))
+
+    host_ip = '1.1.1.1'
+    if ping(host_ip, 3) is False:
+        click.echo("internet NOT available! Please check your connection!")
+        log.critical("Internet not available, exiting")
+        sys.exit(78)
+
+    if timeout > 0:
+        click.echo("Checking for nearest nodes with timeout < {} sec....".format(timeout))
+        nodelist = get_sorted_nodelist(ctx.config["node"], timeout)
+        click.echo("Nearest nodes ->  " + str(nodelist))
+    return nodelist
+
+
 def chain(f):
     @click.pass_context
     def new_func(ctx, *args, **kwargs):
-        nodelist = ctx.config["node"]
-        timeout = int(ctx.obj.get("sortnodes"))
-
-        host_ip = '8.8.8.8'
-        if ping(host_ip, 3) is False:
-            click.echo("internet NOT available! Please check your connection!")
-            log.critical("Internet not available, exiting")
-            sys.exit(78)
-
-        if timeout > 0:
-            click.echo("Checking for nearest nodes with timeout < {} sec....".format(timeout))
-            nodelist = get_sorted_nodelist(ctx.config["node"], timeout)
-            click.echo("Nearest nodes ->  " + str(nodelist))
-
+        nodelist = sort_nodes(ctx)
         ctx.bitshares = BitShares(
             nodelist,
             num_retries=-1,
@@ -155,6 +159,22 @@ def unlock(f):
                     hide_input=True,
                     confirmation_prompt=True)
                 ctx.bitshares.wallet.create(pwd)
+        return ctx.invoke(f, *args, **kwargs)
+    return update_wrapper(new_func, f)
+
+
+def resetnodes(f):
+    @click.pass_context
+    def new_func(ctx, *args, **kwargs):
+        if not os.path.isfile(ctx.obj["configfile"]):
+            Config(path=ctx.obj['configfile'])
+        ctx.config = yaml.safe_load(open(ctx.obj["configfile"]))
+        ctx.config["node"] = Config().node_list # reset to default
+        if ctx.obj.get("sortnodes"):
+            nodelist = sort_nodes(ctx) # sort nodes if option is given
+            ctx.config["node"] = nodelist
+        with open(ctx.obj["configfile"], 'w') as file:
+            yaml.dump(ctx.config, file, default_flow_style=False)
         return ctx.invoke(f, *args, **kwargs)
     return update_wrapper(new_func, f)
 

--- a/dexbot/ui.py
+++ b/dexbot/ui.py
@@ -169,9 +169,11 @@ def resetnodes(f):
         if not os.path.isfile(ctx.obj["configfile"]):
             Config(path=ctx.obj['configfile'])
         ctx.config = yaml.safe_load(open(ctx.obj["configfile"]))
-        ctx.config["node"] = Config().node_list # reset to default
+        # reset to default
+        ctx.config["node"] = Config().node_list
         if ctx.obj.get("sortnodes"):
-            nodelist = sort_nodes(ctx) # sort nodes if option is given
+            nodelist = sort_nodes(ctx)
+            # sort nodes if option is given
             ctx.config["node"] = nodelist
         with open(ctx.obj["configfile"], 'w') as file:
             yaml.dump(ctx.config, file, default_flow_style=False)


### PR DESCRIPTION
provide option on dexbot-cli to reset node list to default. Can be reset to general list, and also can be used with sort option, e.g. ``` dexbot-cli -s 2 resetnodes```