### PR TITLE
Adjust 0 balance message in "both" mode

### DIFF
--- a/dexbot/strategies/king_of_the_hill.py
+++ b/dexbot/strategies/king_of_the_hill.py
@@ -221,9 +221,12 @@ class Strategy(StrategyBase):
 
             amount_base = Decimal(self.amount_base).quantize(Decimal(0).scaleb(-self.market['base']['precision']))
             if not amount_base:
-                self.log.error(
-                    'Cannot place {} order with 0 amount. Adjust your settings or add balance'.format(order_type)
-                )
+                if self.mode == 'both':
+                    self.log.debug('Not placing %s order in "both" mode due to insufficient balance', order_type)
+                else:
+                    self.log.error(
+                        'Cannot place {} order with 0 amount. Adjust your settings or add balance'.format(order_type)
+                    )
                 return False
 
             price = Decimal(self.top_buy_price)
@@ -263,9 +266,12 @@ class Strategy(StrategyBase):
 
             amount_quote = Decimal(self.amount_quote).quantize(Decimal(0).scaleb(-self.market['quote']['precision']))
             if not amount_quote:
-                self.log.error(
-                    'Cannot place {} order with 0 amount. Adjust your settings or add balance'.format(order_type)
-                )
+                if self.mode == 'both':
+                    self.log.debug('Not placing %s order in "both" mode due to insufficient balance', order_type)
+                else:
+                    self.log.error(
+                        'Cannot place {} order with 0 amount. Adjust your settings or add balance'.format(order_type)
+                    )
                 return False
 
             price = Decimal(self.top_sell_price)

--- a/tests/strategies/king_of_the_hill/test_king_of_the_hill.py
+++ b/tests/strategies/king_of_the_hill/test_king_of_the_hill.py
@@ -92,6 +92,13 @@ def test_place_order_zero_amount(worker, other_orders, monkeypatch):
     monkeypatch.setattr(worker.__class__, 'amount_base', 0)
     assert worker.place_order('buy') is False
 
+    # Test other modes too
+    worker.mode = 'buy'
+    assert worker.place_order('buy') is False
+
+    worker.mode = 'sell'
+    assert worker.place_order('sell') is False
+
 
 def test_place_orders(worker2, other_orders):
     """ Test that orders are placed according to mode (buy, sell, buy + sell). Simple test, just make sure buy/sell


### PR DESCRIPTION
To not scary user when some asset has 0 balance in "both" mode, change
log message level to debug.

Despite report, such condition doesn't leads to "worker disabled" error.

Closes: #715